### PR TITLE
Convert header doc style to use our standard doxygen style

### DIFF
--- a/include/graph/algorithm/dijkstra_clrs.hpp
+++ b/include/graph/algorithm/dijkstra_clrs.hpp
@@ -51,8 +51,8 @@ constexpr auto print_types(Ts...) {
  *
  * @param graph The graph.
  * @param source The source vertex.
-*  @param distance The distance vector.
-*  @param predecessor The predecessor vector.
+ * @param distance The distance vector.
+ * @param predecessor The predecessor vector.
  * @param weight The edge weight function.
  *        The edge weight function must be a function object that returns the weight of an edge.
  *        The edge weight function must be copy constructible.

--- a/include/graph/container/csr_graph.hpp
+++ b/include/graph/container/csr_graph.hpp
@@ -27,15 +27,22 @@
 //
 namespace std::graph::container {
 
-/// <summary>
-/// Scans a range used for input for loading edges to determine the largest vertex id used.
-/// </summary>
-/// <typeparam name="EProj">Edge Projection to convert from the input object to a copyable_edge_t<VId,EV></typeparam>
-/// <typeparam name="VId">Vertex Id type</typeparam>
-/// <typeparam name="EV">Edge Value type</typeparam>
-/// <param name="erng">Input range to scan</param>
-/// <param name="eprojection">Projects (converts) a value in erng to a copyable_edge_t<VId,EV></param>
-/// <returns>A pair<VId,size_t> with the max vertex id used and the number of edges scanned.</returns>
+/**
+ * @ingroup graph_containers
+ * @brief Scans a range used for input for loading edges to determine the largest vertex id used.
+ * 
+ * @tparam VId   Vertex Id type.
+ * @tparam EV    Edge value type. It may be void.
+ * @tparam ERng  Edge data range type.
+ * @tparam EProj Edge Projection function type to convert from an @c ERng value type to a @c copyable_edge_t<VId,EV>.
+ *               If the @c ERng value type is already copyable_edge_t<VId,EV> identity can be used.
+ * 
+ * @param erng        The edge data range type.
+ * @param eprojection The edge projection function that converts a @c ERng value type to a @c copyable_edge_t<VId,EV>.
+ *                    If @c erng value type is already copyable_edge_t<VId,EV>, identity() can be used.
+ * 
+ * @return A @c pair<VId,size_t> with the max vertex id used and the number of edges scanned.
+*/
 template <class VId, class EV, ranges::forward_range ERng, class EProj = identity>
 requires copyable_edge<invoke_result<EProj, ranges::range_value_t<ERng>>, VId, EV>
 constexpr auto max_vertex_id(const ERng& erng, const EProj& eprojection) {
@@ -61,18 +68,26 @@ template <class EV        = void,            // edge value type
           class Alloc     = allocator<uint32_t>> // for internal containers
 class csr_graph;
 
-/// <summary>
-/// Wrapper struct for the row index to distinguish it from a vertex_id_type (VId).
-/// </summary>
+/**
+ * @ingroup graph_containers
+ * @brief Wrapper struct for the row index to distinguish it from a vertex_id_type (VId).
+ * 
+ * @tparam EIndex  The type for storing an edge index. It must be able to store a value of |E|+1,
+ *                 where |E| is the total number of edges in the graph.
+*/
 template <integral EIndex>
 struct csr_row {
   using edge_index_type = EIndex;
   edge_index_type index = 0;
 };
 
-/// <summary>
-/// Wrapper struct for the col (edge) index to distinguish it from a vertex_id_type (VId).
-/// </summary>
+/**
+ * @ingroup graph_containers
+ * @brief Wrapper struct for the col (edge) index to distinguish it from a vertex_id_type (VId).
+ * 
+ * @tparam VId     Vertex id type. The type must be able to store a value of |V|+1, where |V| is the
+ *                 number of vertices in the graph.
+*/
 template <integral VId>
 struct csr_col {
   using vertex_id_type = VId;
@@ -80,17 +95,25 @@ struct csr_col {
 };
 
 
-/// <summary>
-/// Class to hold vertex values in a vector that is the same size as row_index_.
-/// If is_void_v<VV> then the class is empty with a single
-/// constructor that accepts (and ignores) an allocator.
-/// </summary>
-/// <typeparam name="EV">Edge Value type, or void if there is none</typeparam>
-/// <typeparam name="VV">Vertex Value type, or void if there is none</typeparam>
-/// <typeparam name="GV">Graph Value type, or void if there is none</typeparam>
-/// <typeparam name="VId">Vertex Id type. This must be large enough for the count of vertices.</typeparam>
-/// <typeparam name="EIndex">Edge Index type. This must be large enough for the count of edges.</typeparam>
-/// <typeparam name="Alloc">Allocator type</typeparam>
+/**
+ * @ingroup graph_containers
+ * @brief Holds vertex values in a vector that is the same size as @c row_index_.
+ * 
+ * If @c is_void_v<VV> then a specialization class is defined that is empty with a single 
+ * constructor that accepts (and ignores) an allocator.
+ * 
+ * @tparam EV      The edge value type. If "void" is used no user value is stored on the edge and 
+ *                 calls to @c edge_value(g,uv) will generate a compile error.
+ * @tparam VV      The vertex value type. If "void" is used no user value is stored on the vertex
+ *                 and calls to @c vertex_value(g,u) will generate a compile error.
+ * @tparam GV      The graph value type. If "void" is used no user value is stored on the graph
+ *                 and calls to @c graph_value(g) will generate a compile error.
+ * @tparam VId     Vertex id type. The type must be able to store a value of |V|+1, where |V| is the
+ *                 number of vertices in the graph.
+ * @tparam EIndex  The type for storing an edge index. It must be able to store a value of |E|+1,
+ *                 where |E| is the total number of edges in the graph.
+ * @tparam Alloc   The allocator type.
+*/
 template <class EV, class VV, class GV, integral VId, integral EIndex, class Alloc>
 class csr_row_values {
   using row_type           = csr_row<EIndex>; // index into col_index_
@@ -223,17 +246,25 @@ public: // Operations
 };
 
 
-/// <summary>
-/// Class to hold vertex values in a vector that is the same size as col_index_.
-/// If is_void_v<EV> then the class is empty with a single
-/// constructor that accepts (and ignores) an allocator.
-/// </summary>
-/// <typeparam name="EV">Edge Value type, or void if there is none</typeparam>
-/// <typeparam name="VV">Vertex Value type, or void if there is none</typeparam>
-/// <typeparam name="GV">Graph Value type, or void if there is none</typeparam>
-/// <typeparam name="VId">Vertex Id type. This must be large enough for the count of vertices.</typeparam>
-/// <typeparam name="EIndex">Edge Index type. This must be large enough for the count of edges.</typeparam>
-/// <typeparam name="Alloc">Allocator type</typeparam>
+/**
+ * @ingroup graph_containers
+ * @brief Class to hold vertex values in a vector that is the same size as col_index_.
+ * 
+ * If is_void_v<EV> then the class is empty with a single
+ * constructor that accepts (and ignores) an allocator.
+ *
+ * @tparam EV      The edge value type. If "void" is used no user value is stored on the edge and 
+ *                 calls to @c edge_value(g,uv) will generate a compile error.
+ * @tparam VV      The vertex value type. If "void" is used no user value is stored on the vertex
+ *                 and calls to @c vertex_value(g,u) will generate a compile error.
+ * @tparam GV      The graph value type. If "void" is used no user value is stored on the graph
+ *                 and calls to @c graph_value(g) will generate a compile error.
+ * @tparam VId     Vertex id type. The type must be able to store a value of |V|+1, where |V| is the
+ *                 number of vertices in the graph.
+ * @tparam EIndex  The type for storing an edge index. It must be able to store a value of |E|+1,
+ *                 where |E| is the total number of edges in the graph.
+ * @tparam Alloc   The allocator type.
+*/
 template <class EV, class VV, class GV, integral VId, integral EIndex, class Alloc>
 class csr_col_values {
   using col_type           = csr_col<VId>; // target_id
@@ -329,16 +360,22 @@ public: // Operations
 };
 
 
-/// <summary>
-/// csr_graph_base - base class for compressed sparse row adjacency graph
-///
-/// </summary>
-/// <typeparam name="EV">Edge value type</typeparam>
-/// <typeparam name="VV">Vertex value type</typeparam>
-/// <typeparam name="GV">Graph value type</typeparam>
-/// <typeparam name="VId">Vertex Id type. This must be large enough for the count of vertices.</typeparam>
-/// <typeparam name="EIndex">Edge Index type. This must be large enough for the count of edges.</typeparam>
-/// <typeparam name="Alloc">Allocator</typeparam>
+/**
+ * @ingroup graph_containers
+ * @brief Base class for compressed sparse row adjacency graph
+ *
+ * @tparam EV      The edge value type. If "void" is used no user value is stored on the edge and 
+ *                 calls to @c edge_value(g,uv) will generate a compile error.
+ * @tparam VV      The vertex value type. If "void" is used no user value is stored on the vertex
+ *                 and calls to @c vertex_value(g,u) will generate a compile error.
+ * @tparam GV      The graph value type. If "void" is used no user value is stored on the graph
+ *                 and calls to @c graph_value(g) will generate a compile error.
+ * @tparam VId     Vertex id type. The type must be able to store a value of |V|+1, where |V| is the
+ *                 number of vertices in the graph.
+ * @tparam EIndex  The type for storing an edge index. It must be able to store a value of |E|+1,
+ *                 where |E| is the total number of edges in the graph.
+ * @tparam Alloc   The allocator type.
+*/
 template <class EV, class VV, class GV, integral VId, integral EIndex, class Alloc>
 class csr_graph_base
       : public csr_row_values<EV, VV, GV, VId, EIndex, Alloc>
@@ -386,14 +423,18 @@ public: // Construction/Destruction
   constexpr csr_graph_base(const Alloc& alloc)
         : row_values_base(alloc), col_values_base(alloc), row_index_(alloc), col_index_(alloc) {}
 
-  /// <summary>
-  /// Constructor that takes a edge range to create the CSR graph.
-  /// Edges must be ordered by source_id (enforced by asssertion).
-  /// </summary>
-  /// <typeparam name="EProj">Edge projection function</typeparam>
-  /// <param name="erng">The input range of edges</param>
-  /// <param name="eprojection">Projection function that creates a copyable_edge_t<VId,EV> from an erng value</param>
-  /// <param name="alloc">Allocator to use for internal containers</param>
+  /**
+   * @brief Constructor that takes a edge range to create the CSR graph.
+   * 
+   * Edges must be ordered by source_id (enforced by asssertion).
+   * 
+   * @tparam ERng   Edge range type
+   * @tparam EProj  Edge projection function type
+   * 
+   * @param erng        The input range of edges
+   * @param eprojection Projection function that creates a @c copyable_edge_t<VId,EV> from an erng value
+   * @param alloc       Allocator to use for internal containers
+  */
   template <ranges::forward_range ERng, class EProj = identity>
   requires copyable_edge<invoke_result<EProj, ranges::range_value_t<ERng>>, VId, EV>
   constexpr csr_graph_base(const ERng& erng, EProj eprojection = {}, const Alloc& alloc = Alloc())
@@ -402,18 +443,22 @@ public: // Construction/Destruction
     load_edges(erng, eprojection);
   }
 
-  /// <summary>
-  /// Constructor that takes edge range and vertex range to create the CSR graph.
-  /// Edges must be ordered by source_id (enforced by asssertion).
-  /// </summary>
-
-  /// <typeparam name="EProj">Edge projection function</typeparam>
-  /// <typeparam name="VProj">Vertex projection function</typeparam>
-  /// <param name="erng">The input range of edges</param>
-  /// <param name="vrng">The input range of vertices</param>
-  /// <param name="eprojection">Projection function that creates a copyable_edge_t<VId,EV> from an erng value</param>
-  /// <param name="vprojection">Projection function that creates a copyable_vertex_t<VId,EV> from a vrng value</param>
-  /// <param name="alloc">Allocator to use for internal containers</param>
+  /**
+   * @brief Constructor that takes edge range and vertex range to create the CSR graph.
+   * 
+   * Edges must be ordered by source_id (enforced by asssertion).
+   *
+   * @tparam ERng   Edge Range type
+   * @tparam VRng   Vetex range type
+   * @tparam EProj  Edge projection function type
+   * @tparam VProj  Vertex projection function type
+   * 
+   * @param erng        The input range of edges
+   * @param vrng        The input range of vertices
+   * @param eprojection Projection function that creates a @c copyable_edge_t<VId,EV> from an @c erng value
+   * @param vprojection Projection function that creates a @c copyable_vertex_t<VId,EV> from a @c vrng value
+   * @param alloc       Allocator to use for internal containers
+  */
   template <ranges::forward_range ERng, ranges::forward_range VRng, class EProj = identity, class VProj = identity>
   //requires copyable_edge<invoke_result<EProj, ranges::range_value_t<ERng>>, VId, EV> &&
   //      copyable_vertex<invoke_result<VProj, ranges::range_value_t<VRng>>, VId, VV>
@@ -427,12 +472,13 @@ public: // Construction/Destruction
     load(erng, vrng, eprojection, vprojection);
   }
 
-  /// <summary>
-  /// Constructor for easy creation of a graph that takes an initializer list
-  /// of copyable_edge_t<VId,EV> -> [source_id, target_id, value].
-  /// </summary>
-  /// <param name="ilist">Initializer list of copyable_edge_t<VId,EV> -> [source_id, target_id, value]</param>
-  /// <param name="alloc">Allocator to use for internal containers</param>
+  /**
+   * @brief Constructor for easy creation of a graph that takes an initializer list 
+   *        of @c copyable_edge_t<VId,EV> -> [source_id, target_id, value].
+   *
+   * @param ilist   Initializer list of @c copyable_edge_t<VId,EV> -> [source_id, target_id, value]
+   * @param alloc   Allocator to use for internal containers
+  */
   constexpr csr_graph_base(const initializer_list<copyable_edge_t<VId, EV>>& ilist, const Alloc& alloc = Alloc())
         : row_values_base(alloc), col_values_base(alloc), row_index_(alloc), col_index_(alloc) {
     load_edges(ilist, identity());
@@ -458,69 +504,79 @@ public: // Operations
     static_cast<col_values_base&>(*this).reserve(count);
   }
 
-  /// <summary>
-  /// Load vertex values. This can be called either before or after load_edges(erng,eproj).
-  ///
-  /// If load_edges(vrng,vproj) has been called before this, the row_values_ vector will be
-  /// extended to match the number of row_index_.size()-1 to avoid out-of-bounds errors when
-  /// accessing vertex values.
-  /// </summary>
-  /// <typeparam name="VProj">Projection function for vrng values</typeparam>
-  /// <param name="vrng">Range of values to load for vertices. The order of the values is preserved in the internal vector.</param>
-  /// <param name="vprojection">Projection function for vrng values</param>
+  /**
+   * @brief Load vertex values, callable either before or after @c load_edges(erng,eproj).
+   *
+   * If @c load_edges(vrng,vproj) has been called before this, the @c row_values_ vector will be
+   * extended to match the number of @c row_index_.size()-1 to avoid out-of-bounds errors when
+   * accessing vertex values.
+   *
+   * @tparam VRng   Vertex range type
+   * @tparam VProj  Vertex projection function type
+   * 
+   * @param  vrng           Range of values to load for vertices. The order of the values is 
+   *                        preserved in the internal vector.
+   * @param  vprojection    Projection function for @c vrng values
+  */
   template <ranges::forward_range VRng, class VProj = identity>
   //requires views::copyable_vertex<invoke_result<VProj, ranges::range_value_t<VRng>>, VId, VV>
   constexpr void load_vertices(const VRng& vrng, VProj vprojection, size_type vertex_count = 0) {
     row_values_base::load_row_values(vrng, vprojection, max(vertex_count, ranges::size(vrng)));
   }
 
-  /// <summary>
-  /// Load vertex values. This can be called either before or after load_edges(erng,eproj).
-  ///
-  /// If load_edges(vrng,vproj) has been called before this, the row_values_ vector will be
-  /// extended to match the number of row_index_.size()-1 to avoid out-of-bounds errors when
-  /// accessing vertex values.
-  /// </summary>
-  /// <typeparam name="VProj">Projection function for vrng values</typeparam>
-  /// <param name="vrng">Range of values to load for vertices. The order of the values is preserved in the internal vector.</param>
-  /// <param name="vprojection">Projection function for vrng values</param>
+  /**
+   * Load vertex values, callable either before or after @c load_edges(erng,eproj).
+   *
+   * If @c load_edges(vrng,vproj) has been called before this, the @c row_values_ vector will be
+   * extended to match the number of @c row_index_.size()-1 to avoid out-of-bounds errors when
+   * accessing vertex values.
+   *
+   * @tparam VRng   Vertex range type
+   * @tparam VProj  Projection function type
+   * 
+   * @param vrng        Range of values to load for vertices. The order of the values is preserved in the internal vector.
+   * @param vprojection Projection function for @c vrng values
+  */
   template <ranges::forward_range VRng, class VProj = identity>
   //requires views::copyable_vertex<invoke_result<VProj, ranges::range_value_t<VRng>>, VId, VV>
   constexpr void load_vertices(VRng& vrng, VProj vprojection = {}, size_type vertex_count = 0) {
     row_values_base::load_row_values(vrng, vprojection, max(vertex_count, ranges::size(vrng)));
   }
 
-  /// <summary>
-  /// Load the edges for the graph. This can be called either before or after load_vertices(erng,eproj).
-  ///
-  /// erng must be ordered by source_id (copyable_edge_t) and is enforced by assertion. target_id
-  /// can be unordered within a source_id.
-  ///
-  /// If erng is bi-directional, the source_id in the last entry is used to determine the maximum
-  /// number of rows and is used to reserve space in the internal row_index and row_value vectors.
-  /// If erng is an input_range or forward_range that evaluation can't be done and the internal
-  /// row_index vector is grown and resized normally as needed (the row_value vector is updated by
-  /// load_vertices(vrng,vproj)). If the caller knows the number of rows/vertices, they can call
-  /// reserve_vertices(n) to reserve the space.
-  ///
-  /// If erng is a sized_range, size(erng) is used to reserve space for the internal col_index and
-  /// v vectors. If it isn't a sized range, the vectors will be grown and resized normally as needed
-  /// as new indexes and values are added. If the caller knows the number of columns/edges, they
-  /// can call reserve_edges(n) to reserve the space.
-  ///
-  /// If row indexes have been referenced in the edges but there are no edges defined for them
-  /// (with source_id), rows will be added to fill out the row_index vector to avoid out-of-bounds
-  /// references.
-  ///
-  /// If load_vertices(vrng,vproj) has been called before this, the row_values_ vector will be
-  /// extended to match the number of row_index_.size()-1 to avoid out-of-bounds errors when
-  /// accessing vertex values.
-  ///
-  /// TODO: ERng not a forward_range because CSV reader doesn't conform to be a forward_range
-  /// </summary>
-  /// <typeparam name="EProj">Edge Projection</typeparam>
-  /// <param name="erng">Input range for edges.</param>
-  /// <param name="eprojection">Edge projection function that returns a copyable_edge_t<VId,EV> for an element in erng</param>
+  /**
+   * @brief Load the edges for the graph, callable either before or after @c load_vertices(erng,eproj).
+   *
+   * @c erng must be ordered by source_id (copyable_edge_t) and is enforced by assertion. target_id
+   * can be unordered within a source_id.
+   *
+   * If @c erng is bi-directional, the source_id in the last entry is used to determine the maximum
+   * number of rows and is used to reserve space in the internal row_index and row_value vectors.
+   * If @c erng is an input_range or forward_range that evaluation can't be done and the internal
+   * row_index vector is grown and resized normally as needed (the row_value vector is updated by
+   * @c load_vertices(vrng,vproj)). If the caller knows the number of rows/vertices, they can call
+   * @c reserve_vertices(n) to reserve the space.
+   *
+   * If @c erng is a sized_range, @c size(erng) is used to reserve space for the internal col_index and
+   * v vectors. If it isn't a sized range, the vectors will be grown and resized normally as needed
+   * as new indexes and values are added. If the caller knows the number of columns/edges, they
+   * can call @c reserve_edges(n) to reserve the space.
+   *
+   * If row indexes have been referenced in the edges but there are no edges defined for them
+   * (with source_id), rows will be added to fill out the row_index vector to avoid out-of-bounds
+   * references.
+   *
+   * If @c load_vertices(vrng,vproj) has been called before this, the row_values_ vector will be
+   * extended to match the number of @c row_index_.size()-1 to avoid out-of-bounds errors when
+   * accessing vertex values.
+   *
+   * @todo @c ERng not a forward_range because CSV reader doesn't conform to be a forward_range
+   * 
+   * @tparam ERng   Edge range type
+   * @tparam EProj  Edge projection function type
+   * 
+   * @param erng        Input range for edges
+   * @param eprojection Edge projection function that returns a @ copyable_edge_t<VId,EV> for an element in @c erng
+  */
   template <class ERng, class EProj = identity>
   //requires views::copyable_edge<invoke_result<EProj, ranges::range_value_t<ERng>>, VId, EV>
   constexpr void load_edges(ERng&& erng, EProj eprojection = {}, size_type vertex_count = 0, size_type edge_count = 0) {
@@ -625,16 +681,19 @@ public: // Operations
       row_values_base::resize(vertex_count);
   }
 
-  /// <summary>
-  /// Load edges and then vertices for the graph. See load_edges() and load_vertices() for more
-  /// information.
-  /// </summary>
-  /// <typeparam name="EProj">Edge Projection Function Type</typeparam>
-  /// <typeparam name="VProj">Vertex Projectiong Function Type</typeparam>
-  /// <param name="erng">Input edge range</param>
-  /// <param name="vrng">Input vertex range</param>
-  /// <param name="eprojection">Edge projection function object</param>
-  /// <param name="vprojection">Vertex projection function object</param>
+  /**
+   * @brief Load edges and then vertices for the graph. 
+   *
+   * See @c load_edges() and @c load_vertices() for more information.
+   *
+   * @tparam EProj Edge Projection Function type
+   * @tparam VProj Vertex Projectiong Function type
+   * 
+   * @param erng        Input edge range
+   * @param vrng        Input vertex range
+   * @param eprojection Edge projection function object
+   * @param vprojection Vertex projection function object
+  */
   template <ranges::forward_range ERng, ranges::forward_range VRng, class EProj = identity, class VProj = identity>
   //requires views::copyable_edge<invoke_result<EProj, ranges::range_value_t<ERng>>, VId, EV> &&
   //      views::copyable_vertex<invoke_result<VProj, ranges::range_value_t<VRng>>, VId, VV>

--- a/include/graph/container/dynamic_graph.hpp
+++ b/include/graph/container/dynamic_graph.hpp
@@ -1199,7 +1199,7 @@ public: // Load operations
   }
 
 #if 0
-  /// TODO: ERng not a forward_range because CSV reader doesn't conform to be a forward_range
+  /// @todo ERng not a forward_range because CSV reader doesn't conform to be a forward_range
   template <class ERng, class EProj = identity>
   void load_edges(ERng&& erng, EProj eproj = {}) {
     // Nothing to do?

--- a/include/graph/views/breadth_first_search.hpp
+++ b/include/graph/views/breadth_first_search.hpp
@@ -187,10 +187,14 @@ protected:
   cancel_search                    cancel_ = cancel_search::continue_search;
 };
 
-//---------------------------------------------------------------------------------------
-/// breadth-first search range for vertices, given a single seed vertex.
-///
-
+/**
+ * @brief Breadth-first search range for vertices, given a single seed vertex.
+ * 
+ * @tparam G     Graph type
+ * @tparam VVF   Vertex Value Function type
+ * @tparam Queue Queue type for internal use
+ * @tparam Alloc Allocator type
+*/
 template <adjacency_list G, class VVF = void, class Queue = queue<vertex_id_t<G>>, class Alloc = allocator<bool>>
 requires ranges::random_access_range<vertex_range_t<G>> && integral<vertex_id_t<G>>
 class vertices_breadth_first_search_view : public bfs_base<G, Queue, Alloc> {
@@ -404,9 +408,14 @@ public:
 };
 
 
-//---------------------------------------------------------------------------------------
-/// breadth-first search range for edges, given a single seed vertex.
-///
+/**
+ * @brief Breadth-first search range for edges, given a single seed vertex.
+ * @tparam G       Graph type
+ * @tparam EVF     Edge Value Function type
+ * @tparam Sourced Does the graph support @c source_id()?
+ * @tparam Queue   Queue type for internal use
+ * @tparam Alloc   Allocator type
+*/
 template <adjacency_list G,
           class EVF    = void,
           bool Sourced = false,

--- a/include/graph/views/depth_first_search.hpp
+++ b/include/graph/views/depth_first_search.hpp
@@ -34,19 +34,22 @@
 
 namespace std::graph {
 
-/// <summary>
-/// The element in a depth-first search stack.
-/// </summary>
+/**
+ * @brief The element in a depth-first search stack.
+*/
 template <adjacency_list G>
 struct dfs_element {
   vertex_id_t<G>            u_id;
   vertex_edge_iterator_t<G> uv;
 };
 
-//---------------------------------------------------------------------------------------
-/// depth-first search view for vertices, given a single seed vertex.
-///
-
+/**
+ * @brief Depth-first search view for vertices, given a single seed vertex.
+ * 
+ * @tparam G     Graph type
+ * @tparam Stack Stack type for internal use
+ * @tparam Alloc Allocator type
+*/
 template <adjacency_list G, class Stack, class Alloc>
 requires ranges::random_access_range<vertex_range_t<G>> && integral<vertex_id_t<G>>
 class dfs_base : public ranges::view_base {
@@ -184,10 +187,14 @@ protected:
 };
 
 
-//---------------------------------------------------------------------------------------
-/// depth-first search range for vertices, given a single seed vertex.
-///
-
+/**
+ * @brief Depth-first search range for vertices, given a single seed vertex.
+ * 
+ * @tparam G     Graph type
+ * @tparam VVF   Vertex Value Function type
+ * @tparam Stack Stack type for internal use
+ * @tparam Alloc Allocator type
+*/
 template <adjacency_list G, class VVF = void, class Stack = stack<dfs_element<G>>, class Alloc = allocator<bool>>
 requires ranges::random_access_range<vertex_range_t<G>> && integral<vertex_id_t<G>>
 class vertices_depth_first_search_view : public dfs_base<G, Stack, Alloc> {
@@ -384,9 +391,15 @@ public:
 };
 
 
-//---------------------------------------------------------------------------------------
-/// depth-first search view for edges, given a single seed vertex.
-///
+/**
+ * @brief Depth-first search view for edges, given a single seed vertex.
+ * 
+ * @tparam G       Graph type
+ * @tparam EVF     Edge Value Function type
+ * @tparam Sourced Does graph G support @c source_id()?
+ * @tparam Stack   Stack type for use internally
+ * @tparam Alloc   Allocator type
+*/
 template <adjacency_list G,
           class EVF    = void,
           bool Sourced = false,

--- a/include/graph/views/edgelist.hpp
+++ b/include/graph/views/edgelist.hpp
@@ -27,14 +27,15 @@ class edgelist_iterator_base {
   using edge_iterator   = vertex_edge_iterator_t<G>;
 
 protected:
-  /// <summary>
-  /// If the current vertex is non-empty then uvi is set to begin(edges(g,*ui)).
-  /// Otherwise, skip past vertices until we find one with edges, and set uvi to the first edge.
-  /// If no vertices with edges are found, ui = end(vertices(g)).
-  /// </summary>
-  /// <param name="g">graph</param>
-  /// <param name="ui">Current vertex</param>
-  /// <param name="uvi">Current edge</param>
+  /**
+   * If the current vertex is non-empty then uvi is set to begin(edges(g,*ui)).
+   * Otherwise, skip past vertices until we find one with edges, and set uvi to the first edge.
+   * If no vertices with edges are found, ui = end(vertices(g)).
+   *
+   * @param g   Graph instance
+   * @param ui  Current vertex
+   * @param uvi Current edge
+  */
   constexpr void find_non_empty_vertex(G& g, vertex_iterator& ui, edge_iterator& uvi) noexcept {
     for (; ui != ranges::end(vertices(g)); ++ui) {
       if (!ranges::empty(edges(g, *ui))) {
@@ -44,13 +45,15 @@ protected:
     }
   }
 
-  /// <summary>
-  /// Find the next edge. Assumes current vertex & edge iterators point to valid
-  /// objects.
-  /// </summary>
-  /// <param name="g">Graph</param>
-  /// <param name="ui">Current vertex</param>
-  /// <param name="uvi">Current edge</param>
+  /**
+   * @brief Find the next edge. 
+   *
+   * Assumes current vertex & edge iterators point to valid objects.
+   * 
+   * @param g   Graph instance
+   * @param ui  Current vertex
+   * @param uvi Current edge
+  */
   constexpr void find_next_edge(G& g, vertex_iterator& ui, edge_iterator& uvi) noexcept {
     assert(ui != ranges::end(vertices(g)));
     assert(uvi != ranges::end(edges(g, *ui)));
@@ -62,11 +65,12 @@ protected:
 };
 
 
-/// <summary>
-/// Iterator for an edgelist range of edges for a vertex.
-/// </summary>
-/// <typeparam name="G">Graph type</typeparam>
-/// <typeparam name="EVF">Edge Value Function</typeparam>
+/**
+ * @brief Iterator for an edgelist range of edges for a vertex.
+ *
+ * @tparam G    Graph type
+ * @tparam EVF  Edge Value Function type
+*/
 template <adjacency_list G, class EVF>
 class edgelist_iterator : public edgelist_iterator_base<G> {
 public:

--- a/include/graph/views/incidence.hpp
+++ b/include/graph/views/incidence.hpp
@@ -20,11 +20,12 @@ namespace std::graph {
 template <adjacency_list G, bool Sourced = false, class EVF = void>
 class incidence_iterator;
 
-/// <summary>
-/// Iterator for an incidence range of edges for a vertex.
-/// </summary>
-/// <typeparam name="G">Graph type</typeparam>
-/// <typeparam name="EVF">Edge Value Function</typeparam>
+/**
+ * @brief Iterator for an incidence range of edges for a vertex.
+ *
+ * @tparam G    Graph type
+ * @tparam EVF  Edge Value Function type
+*/
 template <adjacency_list G, bool Sourced, class EVF>
 class incidence_iterator : source_vertex<G, ((Sourced && !sourced_adjacency_list<G>) || unordered_edge<G, edge_t<G>>)> {
 public:

--- a/include/graph/views/neighbors.hpp
+++ b/include/graph/views/neighbors.hpp
@@ -20,11 +20,12 @@ template <adjacency_list G, bool Sourced = false, class VVF = void>
 class neighbor_iterator;
 
 
-/// <summary>
-/// Iterator for an neighbors range of edges for a vertex.
-/// </summary>
-/// <typeparam name="G">Graph type</typeparam>
-/// <typeparam name="VVF">Edge Value Function</typeparam>
+/**
+ * @brief Iterator for an neighbors range of edges for a vertex.
+ *
+ * @tparam G    Graph type
+ * @tparam VVF  Edge Value Function type
+*/
 template <adjacency_list G, bool Sourced, class VVF>
 class neighbor_iterator
       : public source_vertex<G, ((Sourced && !sourced_adjacency_list<G>) || unordered_edge<G, edge_t<G>>)> {

--- a/include/graph/views/views_utility.hpp
+++ b/include/graph/views/views_utility.hpp
@@ -228,17 +228,18 @@ public:
   source_vertex() = default;
 };
 
-/// <summary>
-/// ref_to_ptr changes a reference to a pointer and stores it as a pointer in value.
-/// Pointers and values are stored as-is.
-///
-/// ref_to_ptr is similar to reference_wrapper but there are a couple of
-/// differences when used in a view iterator that are important:
-/// 1.  It is default constructible, as long as the value being stored is default
-///     constructible.
-/// 2.  It stores a copy of the value if not a reference or a pointer.
-/// </summary>
-/// <typeparam name="T">The type to store</typeparam>
+/**
+ * @brief ref_to_ptr changes a reference to a pointer and stores it as a pointer in value.
+ *        Pointers and values are stored as-is.
+ *
+ * @c ref_to_ptr is similar to @c reference_wrapper but there are a couple of
+ * differences when used in a view iterator that are important:
+ * 1.  It is default constructible, as long as the value being stored is default
+ *     constructible.
+ * 2.  It stores a copy of the value if not a reference or a pointer.
+ *
+ * @tparam T    The type to store
+*/
 namespace _detail {
   template <class T>
   class ref_to_ptr {

--- a/test/csv_routes.hpp
+++ b/test/csv_routes.hpp
@@ -41,15 +41,19 @@
 
 void init_console(); // init cout for UTF-8
 
-/// <summary>
-/// Scans 2 columns in a CSV file and returns all the unique values in an ordered vector.
-/// This is used to get all the unique labels for vertices.
-/// </summary>
-/// <typeparam name="ColNumOrName">A name or integer for a column in the CSV file</typeparam>
-/// <param name="csv_file">The CSV file name (path)</param>
-/// <param name="col1">The first column to get labels from. If the column doesn't exist the function is undefined.</param>
-/// <param name="col2">The second column to get labels from. If the column doesn't exist the function is undefined.</param>
-/// <returns></returns>
+/**
+ * @brief Scans 2 columns in a CSV file and returns all the unique values in an ordered vector.
+ * 
+ * This is used to get all the unique labels for vertices.
+ *
+ * @tparam ColNumOrName A name or integer for a column in the CSV file
+ * 
+ * @param csv_file  The CSV file name (path)
+ * @param col1      The first column to get labels from. If the column doesn't exist the function is undefined.
+ * @param col2      The second column to get labels from. If the column doesn't exist the function is undefined.
+ * 
+ * @return @c pair<vector<string>,size_t> as unique labels, number of rows read
+*/
 template <typename ColNumOrName>
 auto unique_vertex_labels(csv::string_view csv_file, ColNumOrName col1, ColNumOrName col2) {
   csv::CSVReader reader(csv_file); // CSV file reader
@@ -83,19 +87,23 @@ enum struct name_order_policy : int8_t {
   alphabetical        // id assigned after all ids found, in name order
 };
 
-/// <summary>
-/// Scans 2 columns in a CSV file and returns a map<string_view,size>, where the string_view is a
-/// unique label in occurring in either column and size_t is it's unique id.
-/// </summary>
-/// <typeparam name="ColNumOrName">Column name or column number to specify the column in the CSV file</typeparam>
-/// <param name="csv_file">CSV filename</param>
-/// <param name="col1">First column to use</param>
-/// <param name="col2">Second column to use</param>
-/// <param name="order_policy">For order_policy=order_found, the label id is assigned to the row it was
-/// first encountered in the first column. Labels that only occur in the second column will be assigned
-/// a id that follows the other ids in the first column. For order_policy=alphabetical, the id will be
-/// assigned based on the alphabetical ordering of the labels.</param>
-/// <returns></returns>
+/**
+ * @brief Scans 2 columns in a CSV file and returns a @c map<string_view,size>, where the @c string_view is a
+ *        unique label in occurring in either column and @c size_t is it's unique id.
+ *
+ * @tparam ColNumOrName Column name or column number to specify the column in the CSV file
+ * 
+ * @param csv_file      CSV filename
+ * @param col1          First column to use
+ * @param col2          Second column to use
+ * @param order_policy  For @c order_policy=order_found, the label id is assigned to the row it was first 
+ *                      encountered in the first column. Labels that only occur in the second column will 
+ *                      be assigned a id that follows the other ids in the first column. For 
+ *                      @c order_policy=alphabetical, the id will be assigned based on the alphabetical 
+ *                      ordering of the labels.
+ *
+ * @return @c pair<vector<string>,size_t> as unique labels, number of rows read
+*/
 template <typename ColNumOrName, typename VId = uint32_t>
 auto unique_vertex_labels2(csv::string_view        csv_file,
                            ColNumOrName            col1,
@@ -136,15 +144,18 @@ auto unique_vertex_labels2(csv::string_view        csv_file,
 
 
 #ifdef FUTURE
-/// <summary>
-/// Gets the maximum value of two columns in a CSV file with integral values.
-/// </summary>
-/// <typeparam name="T">The integer type that is used to hold the maximum value found</typeparam>
-/// <typeparam name="ColNumOrName">A name or integer for a column in the CSV file</typeparam>
-/// <param name="csv_file">The CSV file name (path)</param>
-/// <param name="col1">The first column to get labels from. If the column doesn't exist the function is undefined</param>
-/// <param name="col2">The second column to get labels from. If the column doesn't exist the function is undefined</param>
-/// <returns></returns>
+/**
+ * @brief Gets the maximum value of two columns in a CSV file with integral values.
+ *
+ * @tparam T            The integer type that is used to hold the maximum value found
+ * @tparam ColNumOrName A name or integer for a column in the CSV file
+ * 
+ * @param csv_file  The CSV file name (path)
+ * @param col1      The first column to get labels from. If the column doesn't exist the function is undefined
+ * @param col2      The second column to get labels from. If the column doesn't exist the function is undefined
+ * 
+ * @return pair<T, size_t> as max_id, number of rows read
+*/
 template <std::integral T, typename ColNumOrName>
 auto max_vertex_id(csv::string_view csv_file, ColNumOrName col1, ColNumOrName col2) {
   csv::CSVReader reader(csv_file); // CSV file reader
@@ -191,16 +202,20 @@ std::graph::vertex_id_t<G> find_city_id(G&& g, std::string_view city_name) {
                                                  begin(std::graph::vertices(g))); // == size(vertices(g)) if not found
 }
 
-/// <summary>
-/// Loads graph such that the vertices are ordered in the same order as the source_id on the edges.
-/// The value of the source_id is not significant. Edges must be ordered by their source_id.
-///
-/// Uses 2 passes the the CSV file. The first is to get the set of unique vertex ids and to create
-/// the vertices. The second pass is used to create the edges.
-/// </summary>
-/// <typeparam name="G"></typeparam>
-/// <param name="csv_file"></param>
-/// <returns></returns>
+/**
+ * @brief Loads graph such that the vertices are ordered in the same order as the source_id on the edges.
+ * 
+ * The value of the source_id is not significant. Edges must be ordered by their source_id.
+ *
+ * Uses 2 passes the the CSV file. The first is to get the set of unique vertex ids and to create
+ * the vertices. The second pass is used to create the edges.
+ *
+ * @tparam G Graph type
+ * 
+ * @param csv_file CSV filename
+ * 
+ * @return A new graph of type G with vertices and edges defined by @c csv_file.
+*/
 template <typename G>
 auto load_graph(csv::string_view csv_file) {
   using namespace std::graph;
@@ -241,21 +256,29 @@ auto load_graph(csv::string_view csv_file) {
   return g;
 }
 
-/// <summary>
-/// Loads a graph such that the vertices are ordered alphabetically by their label so that find_city()
-/// can use std::lower_bound. Edges are shown in the same order as they appear in the CSV, relative
-/// to the source city.
-///
-/// Requires a single pass throught the CSV file to build both a map of unique labels --> vertex_id,
-/// and a "copy" of the rows. The rows have iterators to the unique labels for source and target ids
-/// plus a copy of the values stored.
-///
-/// The resulting graph should give the order as load_graph(csv_file) for vertices but edges may be
-/// ordered differently.
-/// </summary>
-/// <typeparam name="G"></typeparam>
-/// <param name="csv_file"></param>
-/// <returns></returns>
+/**
+ * @brief Loads a graph such that the vertices are ordered alphabetically by their label so that 
+ *        @c find_city() can use @c std::lower_bound(). 
+ *
+ * Edges are shown in the same order as they appear in the CSV, relative to the source city.
+ *
+ * Requires a single pass throught the CSV file to build both a map of unique labels --> vertex_id,
+ * and a "copy" of the rows. The rows have iterators to the unique labels for source and target ids
+ * plus a copy of the values stored.
+ *
+ * The resulting graph should give the order as @c load_graph(csv_file) for vertices but edges may be
+ * ordered differently.
+ * 
+ * @tparam G Graph type
+ * 
+ * @param csv_file              CSV filename
+ * @param order_policy          How should id's be defined? When a vertex name is first encountered or 
+ *                              overall alphabetical order?
+ * @param add_reversed_src_tgt  Should an edge be duplicated with its source_id and target_id reversed?
+ *                              Useful to represent unordered graphs.
+ * 
+ * @return A new graph of type G with vertices and edges defined by @c csv_file.
+*/
 template <typename G>
 auto load_ordered_graph(csv::string_view        csv_file,
                         const name_order_policy order_policy         = name_order_policy::alphabetical,
@@ -451,17 +474,19 @@ OS& operator<<(OS& os, const ostream_indenter& indent) {
 }
 
 
-/// <summary>
-/// Outputs a graphviz file for the routes graph passed.
-///
-/// Example command line to generate image files for file "routes.gv"
-/// dot -Tpdf -O routes.gv
-/// dot -Tpng -O routes.gv
-/// neato -Tpng -O routes.gv
-/// </summary>
-/// <typeparam name="G">Graph type</typeparam>
-/// <param name="g">Grape instance</param>
-/// <param name="filename">Graphviz filename to output</param>
+/**
+ * @brief Outputs a graphviz file for the routes graph passed.
+ *
+ * Example command line to generate image files for file "routes.gv"
+ * dot -Tpdf -O routes.gv
+ * dot -Tpng -O routes.gv
+ * neato -Tpng -O routes.gv
+ *
+ * @tparam G Graph type
+ * 
+ * @param g     Graph instance
+ * @filename    Filename to write to. If the file already exists it will be overwritten.
+*/
 template <class G>
 void output_routes_graphviz(
       const G&           g,
@@ -591,12 +616,14 @@ void output_routes_graphviz_dfs_vertices(
 }
 
 
-/// <summary>
-/// Generates code that can be used for unit tests to validate graph contents haven't changed.
-/// </summary>
-/// <typeparam name="G">Graph type</typeparam>
-/// <param name="g">Graph instance</param>
-/// <param name="name">Descriptive name of the graph</param>
+/**
+ * @brief Generates code that can be used for unit tests to validate graph contents haven't changed.
+ * 
+ * @tparam G Graph type
+ * 
+ * @param g     Graph instance
+ * @param name  Descriptive name of the graph
+*/
 template <class G>
 void generate_routes_tests(const G& g, std::string_view name) {
   using namespace std::graph;

--- a/test/dfs_tests.cpp
+++ b/test/dfs_tests.cpp
@@ -1131,6 +1131,6 @@ void shortest_paths_example() {
   //dijkstra_shortest_paths(g, 1, back_inserter(path));
 }
 } // namespace std::graph
-#endif ///
+#endif // 0
 
 TEST_CASE("shortest paths demo", "[dynamic][shortest_paths][vertex]") {}


### PR DESCRIPTION
Update dijkstra_clrs.hpp to use standard Doxygen style Add @ingroup graph_containers to csr_graph items that didn't have it

Document max_vertex_id()

Update dijkstra_clrs.hpp to use standard Doxygen style

Update csv_routes.hpp to use standard Doxygen style

Update breadth_first_search.hpp to use standard Doxygen style

Update depth_first_search.hpp to use standard Doxygen style

Update edgelist.hpp to use standard Doxygen style

Update incidence.hpp to use standard Doxygen style

Update neighbors.hpp to use standard Doxygen style

Update views_utility.hpp to use standard Doxygen style

Minor changes to text: added @c for code, add missing @tparam entries, etc.