### PR TITLE
Update code to fix Clang-15 warnings and errors in Windows

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -25,6 +25,7 @@
         }
       }
     },
+
     {
       "name": "linux-gcc",
       "inherits": "linux-common",
@@ -66,6 +67,52 @@
       "displayName": "Linux MinSizeRel",
       "description": "Target WSL or a remote Linux system with g++.",
       "inherits": "linux-gcc",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "MinSizeRel"
+      }
+    },
+
+    {
+      "name": "linux-clang",
+      "inherits": "linux-common",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang-14",
+        "CMAKE_CXX_COMPILER": "clang++-14"
+      }
+    },
+    {
+      "name": "linux-clang-debug",
+      "displayName": "Linux Debug",
+      "description": "Target WSL or a remote Linux system with clang++.",
+      "inherits": "linux-clang",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "linux-clang-release",
+      "displayName": "Linux Release",
+      "description": "Target WSL or a remote Linux system with clang++.",
+      "inherits": "linux-clang",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "linux-clang-relWithDebInfo",
+      "displayName": "Linux RelWithDebInfo",
+      "description": "Target WSL or a remote Linux system with clang++.",
+      "inherits": "linux-clang",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+      "name": "linux-clang-minSizeRel",
+      "displayName": "Linux MinSizeRel",
+      "description": "Target WSL or a remote Linux system with clang++.",
+      "inherits": "linux-clang",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "MinSizeRel"
       }
@@ -159,7 +206,54 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "MinSizeRel"
       }
+    },
+
+    {
+      "name": "win-clang-common",
+      "inherits": "windows-common",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang.exe",
+        "CMAKE_CXX_COMPILER": "clang.exe"
+      }
+    },
+    {
+      "name": "win-clang-debug",
+      "inherits": "win-clang-common",
+      "displayName": "Windows x64 Debug",
+      "description": "Target Windows with Visual C++.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "win-clang-release",
+      "inherits": "win-clang-common",
+      "displayName": "Windows x64 Release",
+      "description": "Target Windows with Visual C++.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "win-clang-relWithDebInfo",
+      "inherits": "win-clang-common",
+      "displayName": "Windows x64 RelWithDebInfo",
+      "description": "Target Windows with Visual C++.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+      "name": "win-clang-minSizeRel",
+      "inherits": "win-clang-common",
+      "displayName": "Windows x64 MinSizeRel",
+      "description": "Target Windows with Visual C++.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "MinSizeRel"
+      }
     }
+
   ],
   "buildPresets": [
     {
@@ -183,6 +277,26 @@
       "configuration": "MinSizeRel"
     },
     {
+      "name": "clang-debug",
+      "configurePreset": "linux-clang-debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "clang-release",
+      "configurePreset": "linux-clang-release",
+      "configuration": "Release"
+    },
+    {
+      "name": "clang-relWithDebInfo",
+      "configurePreset": "linux-clang-relWithDebInfo",
+      "configuration": "RelWithDebInfo"
+    },
+    {
+      "name": "clang-minSizeRel",
+      "configurePreset": "linux-clang-minSizeRel",
+      "configuration": "MinSizeRel"
+    },
+    {
       "name": "msvc-debug",
       "configurePreset": "msvc-debug",
       "configuration": "Debug"
@@ -201,6 +315,26 @@
       "name": "msvc-minSizeRel",
       "configurePreset": "msvc-minSizeRel",
       "configuration": "MinSizeRel"
+    },
+    {
+      "name": "win-clang-debug",
+      "configurePreset": "win-clang-debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "win-clang-release",
+      "configurePreset": "win-clang-release",
+      "configuration": "Release"
+    },
+    {
+      "name": "win-clang-relWithDebInfo",
+      "configurePreset": "win-clang-relWithDebInfo",
+      "configuration": "RelWithDebInfo"
+    },
+    {
+      "name": "win-clang-minSizeRel",
+      "configurePreset": "win-clang-minSizeRel",
+      "configuration": "MinSizeRel"
     }
   ],
   "testPresets": [
@@ -218,10 +352,36 @@
       }
     },
     {
+      "name": "clang-debug-test",
+      "description": "test clang",
+      "displayName": "test clang",
+      "configurePreset": "linux-clang-debug",
+      "output": {
+        "outputOnFailure": true
+      },
+      "execution": {
+        "noTestsAction": "error",
+        "stopOnFailure": true
+      }
+    },
+    {
       "name": "msvc-debug-test",
       "description": "test msvc",
       "displayName": "test msvc",
       "configurePreset": "msvc-debug",
+      "output": {
+        "outputOnFailure": true
+      },
+      "execution": {
+        "noTestsAction": "error",
+        "stopOnFailure": true
+      }
+    },
+    {
+      "name": "win-clang-debug-test",
+      "description": "test win-clang",
+      "displayName": "test win-clang",
+      "configurePreset": "win-clang-debug",
       "output": {
         "outputOnFailure": true
       },

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -51,6 +51,9 @@ function(set_project_warnings project_name)
       -Wdouble-promotion # warn if float is implicit promoted to double
       -Wformat=2 # warn on security issues around functions that format output (ie printf)
       -Wimplicit-fallthrough # warn on statements that fallthrough without an explicit annotation
+      -Wno-unused-variable
+      -Wno-unused-parameter
+      -Wno-unused-but-set-variable
   )
 
   if (WARNINGS_AS_ERRORS)

--- a/example/CppCon2022/germany_routes_example.cpp
+++ b/example/CppCon2022/germany_routes_example.cpp
@@ -38,8 +38,8 @@ struct city_id {
 
   template <typename OS>
   friend OS& operator<<(OS& os, const city_id& rhs) {
-    auto&& [g, id] = rhs;
-    os << vertex_value(g, *find_vertex(g, id)) << " [" << id << "]";
+    auto&& [_g, _id] = rhs;
+    os << vertex_value(_g, *find_vertex(_g, _id)) << " [" << _id << "]";
     return os;
   }
 };
@@ -56,8 +56,8 @@ struct city {
 
   template <typename OS>
   friend OS& operator<<(OS& os, const city& rhs) {
-    auto&& [g, id] = rhs;
-    os << vertex_value(g, *find_vertex(g, id));
+    auto&& [_g, _id] = rhs;
+    os << vertex_value(_g, *find_vertex(_g, _id));
     return os;
   }
 };
@@ -113,42 +113,42 @@ TEST_CASE("Germany Routes Presentation", "[presentation][germany][routes][shorte
   // Shortest Paths (segments)
   {
     auto                        weight_1 = [](edge_reference_t<G> uv) -> int { return 1; };
-    std::vector<int>            distance(size(vertices(g)));
+    std::vector<int>            distances(size(vertices(g)));
     std::vector<vertex_id_t<G>> predecessor(size(vertices(g)));
-    dijkstra_clrs(g, frankfurt_id, distance, predecessor, weight_1);
+    dijkstra_clrs(g, frankfurt_id, distances, predecessor, weight_1);
 
     cout << "Shortest distance (segments) from " << city_id(g, frankfurt_id) << endl;
     for (vertex_id_t<G> uid = 0; uid < size(vertices(g)); ++uid)
-      if (distance[uid] > 0)
-        cout << "  --> " << city_id(g, uid) << " - " << distance[uid] << " segments" << endl;
+      if (distances[uid] > 0)
+        cout << "  --> " << city_id(g, uid) << " - " << distances[uid] << " segments" << endl;
   }
 
   // Shortest Paths (km)
   {
     auto                        weight = [&g](edge_reference_t<G> uv) { return edge_value(g, uv); }; // { return 1; };
-    std::vector<double>         distance(size(vertices(g)));
+    std::vector<double>         distances(size(vertices(g)));
     std::vector<vertex_id_t<G>> predecessor(size(vertices(g)));
-    dijkstra_clrs(g, frankfurt_id, distance, predecessor, weight);
+    dijkstra_clrs(g, frankfurt_id, distances, predecessor, weight);
 
     cout << "Shortest distance (km) from " << vertex_value(g, frankfurt) << endl;
     for (vertex_id_t<G> uid = 0; uid < size(vertices(g)); ++uid) {
-      if (distance[uid] > 0)
-        cout << "  --> " << city_id(g, uid) << " - " << distance[uid] << "km" << endl;
+      if (distances[uid] > 0)
+        cout << "  --> " << city_id(g, uid) << " - " << distances[uid] << "km" << endl;
     }
 
     // Find farthest city
     vertex_id_t<G> farthest_id   = frankfurt_id;
     double         farthest_dist = 0.0;
     for (vertex_id_t<G> uid = 0; uid < size(vertices(g)); ++uid) {
-      if (distance[uid] > farthest_dist) {
-        farthest_dist = distance[uid];
+      if (distances[uid] > farthest_dist) {
+        farthest_dist = distances[uid];
         farthest_id   = uid;
       }
     }
 
     // Output path for farthest distance
     cout << "The farthest city from " << city(g, frankfurt_id) << " is " << city(g, farthest_id) << " at "
-         << distance[farthest_id] << "km" << endl;
+         << distances[farthest_id] << "km" << endl;
     cout << "The shortest path from " << city(g, farthest_id) << " to " << city(g, frankfurt_id) << " is: " << endl
          << "  ";
     for (vertex_id_t<G> uid = farthest_id; uid != frankfurt_id; uid = predecessor[uid]) {

--- a/example/CppCon2022/rr_adaptor.hpp
+++ b/example/CppCon2022/rr_adaptor.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "graph/container/container_utility.hpp"
+
 // references for to_tuple
 // https://www.reddit.com/r/cpp/comments/4yp7fv/c17_structured_bindings_convert_struct_to_a_tuple/
 // https://gist.github.com/utilForever/1a058050b8af3ef46b58bcfa01d5375d
@@ -41,14 +43,14 @@ auto to_tuple(T&& object) noexcept {
 template <class T>
 using to_tuple_t = decltype(to_tuple(std::declval<T>()));
 
-template <class C>
-concept has_push_back = requires(C& container, std::ranges::range_reference_t<C> val) {
-                          { container.push_back(val) };
-                        };
-template <class C>
-concept has_push_front = requires(C& container, std::ranges::range_reference_t<C> val) {
-                           { container.push_front(val) };
-                         };
+//template <class C>
+//concept has_push_back = requires(C& container, std::ranges::range_reference_t<C> val) {
+//                          { container.push_back(val) };
+//                        };
+//template <class C>
+//concept has_push_front = requires(C& container, std::ranges::range_reference_t<C> val) {
+//                           { container.push_front(val) };
+//                         };
 
 template <class Outer>
 concept range_of_ranges =
@@ -114,9 +116,9 @@ private:
   }
 
   void push(edges_range& edges, const edge_type& val) {
-    if constexpr (has_push_back<edges_range>)
+    if constexpr (std::graph::container::has_push_back<edges_range>)
       edges.push_back(val);
-    else if constexpr (has_push_front<edges_range>)
+    else if constexpr (std::graph::container::has_push_front<edges_range>)
       edges.push_front(val);
   }
 
@@ -210,7 +212,7 @@ struct rr_edge_value_type {
                                 void>; // Doesn't handle tuple<VId,...>
 };
 template <class V>
-using rr_edge_value_type_t = rr_edge_value_type<V>::type;
+using rr_edge_value_type_t = typename rr_edge_value_type<V>::type;
 
 template <class V>
 struct rr_has_vertex_value : public std::integral_constant<bool, (std::tuple_size_v<to_tuple_t<V>> > 1)> {};
@@ -222,7 +224,7 @@ struct rr_vertex_edges_type {
   using type = std::tuple_element_t<0, to_tuple_t<V>>; // type of scaler or first element of pair, tuple, struct, class
 };
 template <class V>
-using rr_vertex_edges_type_t = rr_vertex_edges_type<V>::type;
+using rr_vertex_edges_type_t = typename rr_vertex_edges_type<V>::type;
 
 template <class V>
 struct rr_vertex_value_type {
@@ -231,7 +233,7 @@ struct rr_vertex_value_type {
                                 void>; // Doesn't handle tuple<T,...>
 };
 template <class V>
-using rr_vertex_value_type_t = rr_vertex_value_type<V>::type;
+using rr_vertex_value_type_t = typename rr_vertex_value_type<V>::type;
 
 template <class Outer>
 concept range_of_ranges2 =
@@ -350,9 +352,9 @@ private:
   }
 
   void push(edges_range& edges, const edge_type& val) {
-    if constexpr (has_push_back<edges_range>)
+    if constexpr (std::graph::container::has_push_back<edges_range>)
       edges.push_back(val);
-    else if constexpr (has_push_front<edges_range>)
+    else if constexpr (std::graph::container::has_push_front<edges_range>)
       edges.push_front(val);
   }
 

--- a/include/graph/container/csr_graph.hpp
+++ b/include/graph/container/csr_graph.hpp
@@ -195,7 +195,7 @@ public: // Operations
       // resize_vertices(n) with enough entries for all the values.
       assert(static_cast<size_t>(id) < size());
 
-      (*this)[id] = move(value);
+      (*this)[id] = std::move(value);
     }
   }
 

--- a/include/graph/container/dynamic_graph.hpp
+++ b/include/graph/container/dynamic_graph.hpp
@@ -367,7 +367,7 @@ public:
 
 public:
   constexpr dynamic_edge_value(const value_type& value) : value_(value) {}
-  constexpr dynamic_edge_value(value_type&& value) : value_(move(value)) {}
+  constexpr dynamic_edge_value(value_type&& value) : value_(std::move(value)) {}
 
   constexpr dynamic_edge_value()                          = default;
   constexpr dynamic_edge_value(const dynamic_edge_value&) = default;
@@ -576,7 +576,7 @@ public:
   constexpr dynamic_edge(vertex_id_type target_id, const value_type& val)
         : base_target_type(target_id), base_value_type(val) {}
   constexpr dynamic_edge(vertex_id_type target_id, value_type&& val)
-        : base_target_type(target_id), base_value_type(move(val)) {}
+        : base_target_type(target_id), base_value_type(std::move(val)) {}
 
   constexpr dynamic_edge()                    = default;
   constexpr dynamic_edge(const dynamic_edge&) = default;
@@ -701,14 +701,14 @@ private: // tag_invoke properties
     return u.edges_;
   }
 
-  friend constexpr edges_type::iterator
+  friend constexpr typename edges_type::iterator
   tag_invoke(::std::graph::tag_invoke::find_vertex_edge_fn_t, graph_type& g, vertex_id_type uid, vertex_id_type vid) {
     return ranges::find(g[uid].edges_, [&g, &vid](const edge_type& uv) -> bool { return target_id(g, uv) == vid; });
   }
-  friend constexpr edges_type::const_iterator tag_invoke(::std::graph::tag_invoke::find_vertex_edge_fn_t,
-                                                         const graph_type& g,
-                                                         vertex_id_type    uid,
-                                                         vertex_id_type    vid) {
+  friend constexpr typename edges_type::const_iterator tag_invoke(::std::graph::tag_invoke::find_vertex_edge_fn_t,
+                                                                  const graph_type& g,
+                                                                  vertex_id_type    uid,
+                                                                  vertex_id_type    vid) {
     return ranges::find(g[uid].edges_, [&g, &vid](const edge_type& uv) -> bool { return target_id(g, uv) == vid; });
   }
 };
@@ -858,7 +858,7 @@ public: // types
   using vertex_type           = dynamic_vertex<EV, VV, GV, VId, Sourced, Traits>;
   using vertices_type         = typename Traits::vertices_type;
   using vertex_allocator_type = typename vertices_type::allocator_type;
-  using size_type             = vertices_type::size_type;
+  using size_type             = typename vertices_type::size_type;
 
   using edges_type          = typename Traits::edges_type;
   using edge_allocator_type = typename edges_type::allocator_type;
@@ -1064,7 +1064,7 @@ public: // Load operations
       size_t k           = static_cast<size_t>(id);
       if constexpr (ranges::random_access_range<vertices_type>)
         assert(k < vertices_.size());
-      vertices_[k].value() = move(value);
+      vertices_[k].value() = std::move(value);
     }
   }
 
@@ -1117,15 +1117,15 @@ public: // Load operations
       auto&& edge_adder = push_or_insert(vertices_[e.source_id].edges());
       if constexpr (Sourced) {
         if constexpr (is_void_v<EV>) {
-          edge_adder(edge_type(move(e.source_id), move(e.target_id)));
+          edge_adder(edge_type(std::move(e.source_id), std::move(e.target_id)));
         } else {
-          edge_adder(edge_type(move(e.source_id), move(e.target_id), move(e.value)));
+          edge_adder(edge_type(std::move(e.source_id), std::move(e.target_id), std::move(e.value)));
         }
       } else {
         if constexpr (is_void_v<EV>) {
-          edge_adder(edge_type(move(e.target_id)));
+          edge_adder(edge_type(std::move(e.target_id)));
         } else {
-          edge_adder(edge_type(move(e.target_id), move(e.value)));
+          edge_adder(edge_type(std::move(e.target_id), std::move(e.value)));
         }
       }
     }
@@ -1184,15 +1184,15 @@ public: // Load operations
       auto&& edge_adder = push_or_insert(vertices_[e.source_id].edges());
       if constexpr (Sourced) {
         if constexpr (is_void_v<EV>) {
-          edge_adder(edge_type(move(e.source_id), move(e.target_id)));
+          edge_adder(edge_type(std::move(e.source_id), std::move(e.target_id)));
         } else {
-          edge_adder(edge_type(move(e.source_id), move(e.target_id), move(e.value)));
+          edge_adder(edge_type(std::move(e.source_id), std::move(e.target_id), std::move(e.value)));
         }
       } else {
         if constexpr (is_void_v<EV>) {
-          edge_adder(edge_type(move(e.target_id)));
+          edge_adder(edge_type(std::move(e.target_id)));
         } else {
-          edge_adder(edge_type(move(e.target_id), move(e.value)));
+          edge_adder(edge_type(std::move(e.target_id), std::move(e.value)));
         }
       }
     }
@@ -1230,8 +1230,8 @@ public: // Properties
 
   constexpr auto size() const noexcept { return vertices_.size(); }
 
-  constexpr vertices_type::value_type&       operator[](size_type i) noexcept { return vertices_[i]; }
-  constexpr const vertices_type::value_type& operator[](size_type i) const noexcept { return vertices_[i]; }
+  constexpr typename vertices_type::value_type&       operator[](size_type i) noexcept { return vertices_[i]; }
+  constexpr const typename vertices_type::value_type& operator[](size_type i) const noexcept { return vertices_[i]; }
 
 public: // Operations
   void reserve_vertices(size_type count) {
@@ -1262,8 +1262,9 @@ private: // tag_invoke properties
     return g.vertices_;
   }
 
-  friend vertex_id_type
-  tag_invoke(::std::graph::tag_invoke::vertex_id_fn_t, const dynamic_graph_base& g, vertices_type::const_iterator ui) {
+  friend vertex_id_type tag_invoke(::std::graph::tag_invoke::vertex_id_fn_t,
+                                   const dynamic_graph_base&              g,
+                                   typename vertices_type::const_iterator ui) {
     return static_cast<vertex_id_type>(ui - g.vertices_.begin());
   }
 
@@ -1675,7 +1676,7 @@ public: // Types & Constants
   using vertex_id_type = VId;
   using value_type     = void;
   using allocator_type = typename Traits::vertices_type::allocator_type;
-  using base_type::vertices_type;
+  using typename base_type::vertices_type;
 
   using edges_type          = typename Traits::edges_type;
   using edge_allocator_type = typename edges_type::allocator_type;

--- a/include/graph/views/vertexlist.hpp
+++ b/include/graph/views/vertexlist.hpp
@@ -228,7 +228,7 @@ constexpr auto vertexlist(G&& g) {
   if constexpr (std::graph::tag_invoke::_has_vertexlist_g_adl<G>)
     return std::graph::tag_invoke::vertexlist(forward<G>(g));
   else
-    return vertexlist_view<G>(vertices(forward<G>(g)));
+    return vertexlist_view<G>(vertices(std::forward<G>(g)));
 }
 
 template <adjacency_list G, class VVF>

--- a/tests/csv_routes.hpp
+++ b/tests/csv_routes.hpp
@@ -232,7 +232,8 @@ auto load_graph(csv::string_view csv_file) {
   graph_type g;
 
   // Load vertices
-  auto city_id_getter = [&city_names](const city_id_map& name_id) {
+  auto&& cnames         = city_names; // Clang-15 not finding city_names for following capture
+  auto   city_id_getter = [&cnames](const city_id_map& name_id) {
     using copyable_id_name = std::graph::copyable_vertex_t<vertex_id_type, std::string>;
     return copyable_id_name{name_id.second,
                             name_id.first}; // {id,name} don't move name b/c we need to keep it in the map
@@ -368,7 +369,7 @@ auto load_ordered_graph(csv::string_view        csv_file,
   g.load_vertices(ordered_cities, city_name_getter);
 
   // load edges
-  auto eproj = [&g](csv_row_type& row) {
+  auto eproj = [](csv_row_type& row) {
     using graph_copyable_edge_type = copyable_edge_t<vertex_id_type, edge_value_type>;
     graph_copyable_edge_type retval{static_cast<vertex_id_type>(row.source_id->second),
                                     static_cast<vertex_id_type>(row.target_id->second), row.value};


### PR DESCRIPTION
Update CMakePresets.json to include Clang for Windows & Linux builds

This is pull request is for support of clang-15 in Windows. It doesn't include Linux with clang-14.

Add Clang warnings suppression  in CompilerWarnings.cmake