### PR TITLE
Add comments to indicate concept is For exposition only

### DIFF
--- a/include/graph/algorithm/mst.hpp
+++ b/include/graph/algorithm/mst.hpp
@@ -98,32 +98,32 @@ bool disjoint_union_find(disjoint_vector<VId>& subsets, VId u, VId v) {
 //concept has_edge_value = requires(ED ed) { requires !same_as<decltype(ed.value), void>; };
 
 
-template <class ELVT>
+template <class ELVT> // For exposition only
 concept _has_edgelist_value = !is_void_v<typename ELVT::value_type>;
 
-template <class ELVT>
+template <class ELVT> // For exposition only
 concept _basic_edgelist_type = is_same_v<typename ELVT::target_id_type, typename ELVT::source_id_type>;
 
-template <class ELVT>
+template <class ELVT> // For exposition only
 concept _basic_index_edgelist_type = _basic_edgelist_type<ELVT> && is_integral_v<typename ELVT::target_id_type>;
 
-template <class ELVT>
+template <class ELVT> // For exposition only
 concept _edgelist_type = _basic_edgelist_type<ELVT> && _has_edgelist_value<ELVT>;
 
-template <class ELVT>
+template <class ELVT> // For exposition only
 concept _index_edgelist_type = _basic_index_edgelist_type<ELVT> && _has_edgelist_value<ELVT>;
 
 
-template <class EL>
+template <class EL> // For exposition only
 concept basic_edgelist_range = ranges::forward_range<EL> && _basic_edgelist_type<ranges::range_value_t<EL>>;
 
-template <class EL>
+template <class EL> // For exposition only
 concept basic_index_edgelist_range = ranges::forward_range<EL> && _basic_index_edgelist_type<ranges::range_value_t<EL>>;
 
-template <class EL>
+template <class EL> // For exposition only
 concept edgelist_range = ranges::forward_range<EL> && _edgelist_type<ranges::range_value_t<EL>>;
 
-template <class EL>
+template <class EL> // For exposition only
 concept index_edgelist_range = ranges::forward_range<EL> && _index_edgelist_type<ranges::range_value_t<EL>>;
 
 

--- a/include/graph/algorithm/shortest_paths.hpp
+++ b/include/graph/algorithm/shortest_paths.hpp
@@ -24,14 +24,14 @@
 
 namespace std::graph {
 
-template <class G, class WF, class DistanceValue, class Compare, class Combine>
-concept basic_edge_weight_function = // e.g. weight(uv)
+template <class G, class WF, class DistanceValue, class Compare, class Combine> // For exposition only
+concept basic_edge_weight_function =                                            // e.g. weight(uv)
       is_arithmetic_v<DistanceValue> && strict_weak_order<Compare, DistanceValue, DistanceValue> &&
       assignable_from<add_lvalue_reference_t<DistanceValue>,
                       invoke_result_t<Combine, DistanceValue, invoke_result_t<WF, edge_reference_t<G>>>>;
 
-template <class G, class WF, class DistanceValue>
-concept edge_weight_function = // e.g. weight(uv)
+template <class G, class WF, class DistanceValue> // For exposition only
+concept edge_weight_function =                    // e.g. weight(uv)
       is_arithmetic_v<invoke_result_t<WF, edge_reference_t<G>>> &&
       basic_edge_weight_function<G, WF, DistanceValue, less<DistanceValue>, plus<DistanceValue>>;
 
@@ -150,8 +150,8 @@ template <index_adjacency_list        G,
           class WF        = function<ranges::range_value_t<Distances>(edge_reference_t<G>)>, //
           class Allocator = allocator<vertex_id_t<G>>                                        //
           >
-requires is_arithmetic_v<ranges::range_value_t<Distances>> &&                   //
-         convertible_to<vertex_id_t<G>, ranges::range_value_t<Predecessors>> && //
+requires is_arithmetic_v<ranges::range_value_t<Distances>> &&                                //
+         convertible_to<vertex_id_t<G>, ranges::range_value_t<Predecessors>> &&              //
          edge_weight_function<G, WF, ranges::range_value_t<Distances>>
 void dijkstra_shortest_paths(
       G&&            g,            // graph
@@ -219,7 +219,7 @@ template <index_adjacency_list        G,
           class WF        = std::function<ranges::range_value_t<Distances>(edge_reference_t<G>)>, //
           class Allocator = allocator<vertex_id_t<G>>                                             //
           >
-requires is_arithmetic_v<ranges::range_value_t<Distances>> && //
+requires is_arithmetic_v<ranges::range_value_t<Distances>> &&                                     //
          edge_weight_function<G, WF, ranges::range_value_t<Distances>>
 void dijkstra_shortest_distances(
       G&&            g,         // graph
@@ -260,8 +260,8 @@ template <index_adjacency_list        G,
           class WF        = function<ranges::range_value_t<Distances>(edge_reference_t<G>)>, //
           class Allocator = allocator<vertex_id_t<G>>                                        //
           >
-requires is_arithmetic_v<ranges::range_value_t<Distances>> &&                   //
-         convertible_to<vertex_id_t<G>, ranges::range_value_t<Predecessors>> && //
+requires is_arithmetic_v<ranges::range_value_t<Distances>> &&                                //
+         convertible_to<vertex_id_t<G>, ranges::range_value_t<Predecessors>> &&              //
          basic_edge_weight_function<G, WF, ranges::range_value_t<Distances>, Compare, Combine>
 void dijkstra_shortest_paths(
       G&&            g,            // graph
@@ -333,7 +333,7 @@ template <index_adjacency_list        G,
           class WF        = std::function<ranges::range_value_t<Distances>(edge_reference_t<G>)>, //
           class Allocator = allocator<vertex_id_t<G>>                                             //
           >
-requires is_arithmetic_v<ranges::range_value_t<Distances>> && //
+requires is_arithmetic_v<ranges::range_value_t<Distances>> &&                                     //
          basic_edge_weight_function<G, WF, ranges::range_value_t<Distances>, Compare, Combine>
 void dijkstra_shortest_distances(
       G&&            g,         // graph

--- a/include/graph/graph.hpp
+++ b/include/graph/graph.hpp
@@ -73,13 +73,13 @@ namespace std::graph {
  * @tparam G The graph type.
  * @tparam E The edge type.
  */
-template <class G, class E>
+template <class G, class E> // For exposition only
 concept basic_targeted_edge = requires(G&& g, edge_reference_t<G> uv) { target_id(g, uv); };
 
-template <class G, class E>
+template <class G, class E> // For exposition only
 concept basic_sourced_edge = requires(G&& g, edge_reference_t<G> uv) { source_id(g, uv); };
 
-template <class G, class E>
+template <class G, class E>                                        // For exposition only
 concept basic_sourced_targeted_edge = basic_targeted_edge<G, E> && //
                                       basic_sourced_edge<G, E> &&  //
                                       requires(G&& g, edge_reference_t<G> uv) { edge_id(g, uv); };
@@ -94,15 +94,15 @@ concept basic_sourced_targeted_edge = basic_targeted_edge<G, E> && //
  * @tparam G The graph type.
  * @tparam E The edge type.
  */
-template <class G, class E>
+template <class G, class E>                          // For exposition only
 concept targeted_edge = basic_targeted_edge<G, E> && //
                         requires(G&& g, edge_reference_t<G> uv) { target(g, uv); };
 
-template <class G, class E>
+template <class G, class E>                        // For exposition only
 concept sourced_edge = basic_sourced_edge<G, E> && //
                        requires(G&& g, edge_reference_t<G> uv) { source(g, uv); };
 
-template <class G, class E>
+template <class G, class E>                            // For exposition only
 concept sourced_targeted_edge = targeted_edge<G, E> && //
                                 sourced_edge<G, E> &&  //
                                 requires(G&& g, edge_reference_t<G> uv) { edge_id(g, uv); };
@@ -124,11 +124,11 @@ template <class G>                                                       // (exp
 concept _common_vertex_range = ranges::sized_range<vertex_range_t<G>> && //
                                requires(G&& g, vertex_iterator_t<G> ui) { vertex_id(g, ui); };
 
-template <class G>
+template <class G>                                                // For exposition only
 concept vertex_range = _common_vertex_range<vertex_range_t<G>> && //
                        ranges::forward_range<vertex_range_t<G>>;
 
-template <class G>
+template <class G>                                                             // For exposition only
 concept index_vertex_range = _common_vertex_range<vertex_range_t<G>> &&        //
                              ranges::random_access_range<vertex_range_t<G>> && //
                              integral<vertex_id_t<G>>;
@@ -142,12 +142,12 @@ concept index_vertex_range = _common_vertex_range<vertex_range_t<G>> &&        /
  * @ingroup graph_concepts
  * @brief Concept for a target edge range
 */
-template <class G>
+template <class G> // For exposition only
 concept basic_targeted_edge_range = requires(G&& g, vertex_id_t<G> uid) {
   { edges(g, uid) } -> ranges::forward_range;
 };
 
-template <class G>
+template <class G>                                            // For exposition only
 concept targeted_edge_range = basic_targeted_edge_range<G> && //
                               requires(G&& g, vertex_reference_t<G> u) {
                                 { edges(g, u) } -> ranges::forward_range;
@@ -164,7 +164,7 @@ concept targeted_edge_range = basic_targeted_edge_range<G> && //
  * 
  * @tparam G The graph type.
 */
-template <class G>
+template <class G>                                             // For exposition only
 concept basic_adjacency_list = vertex_range<G> &&              //
                                basic_targeted_edge_range<G> && //
                                targeted_edge<G, edge_t<G>>;
@@ -179,7 +179,7 @@ concept basic_adjacency_list = vertex_range<G> &&              //
  * 
  * @tparam G The graph type.
 */
-template <class G>
+template <class G>                                                   // For exposition only
 concept basic_index_adjacency_list = index_vertex_range<G> &&        //
                                      basic_targeted_edge_range<G> && //
                                      basic_targeted_edge<G, edge_t<G>>;
@@ -192,7 +192,7 @@ concept basic_index_adjacency_list = index_vertex_range<G> &&        //
  * 
  * @tparam G The graph type.
 */
-template <class G>
+template <class G>                                                     // For exposition only
 concept basic_sourced_adjacency_list = vertex_range<G> &&              //
                                        basic_targeted_edge_range<G> && //
                                        basic_sourced_targeted_edge<G, edge_t<G>>;
@@ -207,7 +207,7 @@ concept basic_sourced_adjacency_list = vertex_range<G> &&              //
  * 
  * @tparam G The graph type.
 */
-template <class G>
+template <class G>                                                           // For exposition only
 concept basic_sourced_index_adjacency_list = index_vertex_range<G> &&        //
                                              basic_targeted_edge_range<G> && //
                                              basic_sourced_targeted_edge<G, edge_t<G>>;
@@ -223,7 +223,7 @@ concept basic_sourced_index_adjacency_list = index_vertex_range<G> &&        //
  * 
  * @tparam G The graph type.
 */
-template <class G>
+template <class G>                                 // For exposition only
 concept adjacency_list = vertex_range<G> &&        //
                          targeted_edge_range<G> && //
                          targeted_edge<G, edge_t<G>>;
@@ -238,7 +238,7 @@ concept adjacency_list = vertex_range<G> &&        //
  * 
  * @tparam G The graph type.
 */
-template <class G>
+template <class G>                                       // For exposition only
 concept index_adjacency_list = index_vertex_range<G> &&  //
                                targeted_edge_range<G> && //
                                targeted_edge<G, edge_t<G>>;
@@ -252,7 +252,7 @@ concept index_adjacency_list = index_vertex_range<G> &&  //
  * 
  * @tparam G The graph type.
 */
-template <class G>
+template <class G>                                         // For exposition only
 concept sourced_adjacency_list = vertex_range<G> &&        //
                                  targeted_edge_range<G> && //
                                  sourced_targeted_edge<G, edge_t<G>>;
@@ -267,7 +267,7 @@ concept sourced_adjacency_list = vertex_range<G> &&        //
  * 
  * @tparam G The graph type.
 */
-template <class G>
+template <class G>                                               // For exposition only
 concept sourced_index_adjacency_list = index_vertex_range<G> &&  //
                                        targeted_edge_range<G> && //
                                        sourced_targeted_edge<G, edge_t<G>>;
@@ -315,7 +315,7 @@ inline constexpr bool is_sourced_edge_v = is_sourced_edge<G, E>::value;
  * 
  * @tparam G The graph type
 */
-template <class G>
+template <class G> // For exposition only
 concept has_degree = requires(G&& g, vertex_reference_t<G> u) {
   { degree(g, u) };
 };
@@ -332,7 +332,7 @@ concept has_degree = requires(G&& g, vertex_reference_t<G> u) {
  * 
  * @tparam G The graph type
 */
-template <class G>
+template <class G> // For exposition only
 concept has_find_vertex = requires(G&& g, vertex_id_t<G> uid) {
   { find_vertex(g, uid) } -> forward_iterator;
 };
@@ -345,7 +345,7 @@ concept has_find_vertex = requires(G&& g, vertex_id_t<G> uid) {
  * 
  * @tparam G The graph type
 */
-template <class G>
+template <class G> // For exposition only
 concept has_find_vertex_edge = requires(G&& g, vertex_id_t<G> uid, vertex_id_t<G> vid, vertex_reference_t<G> u) {
   { find_vertex_edge(g, u, vid) } -> forward_iterator;
   { find_vertex_edge(g, uid, vid) } -> forward_iterator;
@@ -359,7 +359,7 @@ concept has_find_vertex_edge = requires(G&& g, vertex_id_t<G> uid, vertex_id_t<G
  * 
  * @tparam G The graph type
 */
-template <class G>
+template <class G> // For exposition only
 concept has_contains_edge = requires(G&& g, vertex_id_t<G> uid, vertex_id_t<G> vid) {
   { contains_edge(g, uid, vid) } -> convertible_to<bool>;
 };
@@ -436,7 +436,7 @@ struct is_unordered_edge : public conjunction<define_unordered_edge<E>, is_sourc
 template <class G, class E>
 inline constexpr bool is_unordered_edge_v = is_unordered_edge<G, E>::value;
 
-template <class G, class E>
+template <class G, class E> // For exposition only
 concept unordered_edge = is_unordered_edge_v<G, E>;
 
 //
@@ -448,7 +448,7 @@ struct is_ordered_edge : public negation<is_unordered_edge<G, E>> {};
 template <class G, class E>
 inline constexpr bool is_ordered_edge_v = is_ordered_edge<G, E>::value;
 
-template <class G, class E>
+template <class G, class E> // For exposition only
 concept ordered_edge = is_ordered_edge_v<G, E>;
 
 

--- a/include/graph/graph_descriptors.hpp
+++ b/include/graph/graph_descriptors.hpp
@@ -271,19 +271,19 @@ struct neighbor_descriptor<VId, true, void, void> {
 //
 // copyable_edge_t
 //
-template <class VId, class VV>
+template <class VId, class VV>                                        // For exposition only
 using copyable_neighbor_t = neighbor_descriptor<VId, true, void, VV>; // {source_id, target_id [, value]}
 
 //
 // view concepts
 //
-template <class T, class VId, class VV>
+template <class T, class VId, class VV> // For exposition only
 concept copyable_vertex = convertible_to<T, copyable_vertex_t<VId, VV>>;
 
-template <class T, class VId, class EV>
+template <class T, class VId, class EV> // For exposition only
 concept copyable_edge = convertible_to<T, copyable_edge_t<VId, EV>>;
 
-template <class T, class VId, class EV>
+template <class T, class VId, class EV> // For exposition only
 concept copyable_neighbor = convertible_to<T, copyable_neighbor_t<VId, EV>>;
 
 //


### PR DESCRIPTION
Adding a concept to the standard is a serious endeavor because it can never be changed. This softens the recommendation until we have consensus.

We believe there is merit to adding concept(s) for an adjancy_list and edgelist have merit because they introduce new type not currently in the standard, namely a range of ranges compared to 1-dimensional range for traditional containers.

The alternative is to unwind/expand the concept defintions and add the result in the requires clause.