### PR TITLE
fix usage of FetchContent for dependencies

### DIFF
--- a/cmake/FetchCSVParser.cmake
+++ b/cmake/FetchCSVParser.cmake
@@ -8,13 +8,7 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/pratzl/csv-parser.git
     GIT_TAG        2.1.3
 )
+FetchContent_MakeAvailable(csv_parser)
 
-FetchContent_GetProperties(csv_parser)
-if(NOT csv_parser_POPULATED)
-  FetchContent_Populate(
-    csv_parser
-  )
-endif()
 set(CSVPARSER_INCLUDE_DIR "${csv_parser_SOURCE_DIR}/single_include")
 
-FetchContent_MakeAvailable(csv_parser)

--- a/cmake/FetchCatch.cmake
+++ b/cmake/FetchCatch.cmake
@@ -8,16 +8,7 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
     GIT_TAG        v3.5.2
 )
-
-FetchContent_GetProperties(catch2)
-if(NOT catch2_POPULATED)
-  FetchContent_Populate(
-    catch2
-  )
-endif()
-
+FetchContent_MakeAvailable(catch2)
 set(CATCH2_SOURCE_DIR "${catch2_SOURCE_DIR}")
 set(CATCH2_INCLUDE_DIR "${catch2_INCLUDE_DIR}")
 
-FetchContent_MakeAvailable(catch2)
-add_subdirectory(${catch2_SOURCE_DIR})

--- a/cmake/FetchDocopt.cmake
+++ b/cmake/FetchDocopt.cmake
@@ -8,15 +8,7 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/docopt/docopt.cpp.git
     GIT_TAG        v0.6.3
 )
-
-FetchContent_GetProperties(docopt)
-if(NOT docopt_POPULATED)
-  FetchContent_Populate(
-    docopt
-  )
-endif()
-
+FetchContent_MakeAvailable(docopt)
 set(DOCOPT_SOURCE_DIR "${docopt_SOURCE_DIR}")
 set(DOCOPT_INCLUDE_DIR "${docopt_INCLUDE_DIR}")
 
-FetchContent_MakeAvailable(docopt)

--- a/cmake/FetchFMT.cmake
+++ b/cmake/FetchFMT.cmake
@@ -8,16 +8,8 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/fmtlib/fmt.git
     GIT_TAG        10.2.1
 )
-
-FetchContent_GetProperties(fmt)
-if(NOT fmt_POPULATED)
-  FetchContent_Populate(
-    fmt
-  )
-endif()
-
+FetchContent_MakeAvailable(fmt)
 set(FMT_SOURCE_DIR "${fmt_SOURCE_DIR}")
 set(FMT_INCLUDE_DIR "${fmt_INCLUDE_DIR}")
 
-FetchContent_MakeAvailable(fmt)
-add_subdirectory(${fmt_SOURCE_DIR})
+

--- a/cmake/FetchRange.cmake
+++ b/cmake/FetchRange.cmake
@@ -8,15 +8,7 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/ericniebler/range-v3.git
     GIT_TAG        0.11.0
 )
-
-FetchContent_GetProperties(range)
-if(NOT range_POPULATED)
-  FetchContent_Populate(
-    range
-  )
-endif()
-
+FetchContent_MakeAvailable(range)
 set(RANGE_SOURCE_DIR "${range_SOURCE_DIR}")
 set(RANGE_INCLUDE_DIR "${range_INCLUDE_DIR}")
 
-FetchContent_MakeAvailable(range)

--- a/cmake/FetchSPDLog.cmake
+++ b/cmake/FetchSPDLog.cmake
@@ -8,15 +8,7 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/gabime/spdlog.git
     GIT_TAG        v1.9.2
 )
-
-FetchContent_GetProperties(spdlog)
-if(NOT spdlog_POPULATED)
-  FetchContent_Populate(
-    spdlog
-  )
-endif()
-
+FetchContent_MakeAvailable(spdlog)
 set(SPDLOG_SOURCE_DIR "${spdlog_SOURCE_DIR}")
 set(SPDLOG_INCLUDE_DIR "${spdlog_INCLUDE_DIR}")
 
-FetchContent_MakeAvailable(spdlog)


### PR DESCRIPTION
see https://github.com/stdgraph/graph-v2/issues/111 

- Allows for graph-v2 to be consumed by FetchContent
- Removes extraneous calls to both `FetchContent_Populate` and `FetchContent_MakeAvailable`

Note: the only Fetch file I didn't touch was for boost, as I was unsure what the intention behind the `add_subdirectory` in the populate call, specifically the `EXCLUDE_FROM_ALL` (see below), but the call to include this CMake file is commented out in the main CMakeLists file, so I just left it as is from now.

```
FetchContent_GetProperties(boost)
if(NOT boost_POPULATED)
    FetchContent_Populate(boost)
    add_subdirectory(
        ${boost_SOURCE_DIR}
        ${boost_BINARY_DIR}
        EXCLUDE_FROM_ALL
    )
endif()
```