### PR TITLE
Additional std:: types and functions to graph_using.hpp

### DIFF
--- a/include/graph/algorithm/bellman_ford_shortest_paths.hpp
+++ b/include/graph/algorithm/bellman_ford_shortest_paths.hpp
@@ -37,18 +37,12 @@ public:
 
   // Visitor Functions
 public:
-  // vertex visitor functions
-  //constexpr void on_initialize_vertex(vertex_desc_type&& vdesc) {}
-  //constexpr void on_discover_vertex(vertex_desc_type&& vdesc) {}
-  //constexpr void on_examine_vertex(vertex_desc_type&& vdesc) {}
-  //constexpr void on_finish_vertex(vertex_desc_type&& vdesc) {}
-
   // edge visitor functions
-  constexpr void on_examine_edge(sourced_edge_desc_type&& edesc) {}
-  constexpr void on_edge_relaxed(sourced_edge_desc_type&& edesc) {}
-  constexpr void on_edge_not_relaxed(sourced_edge_desc_type&& edesc) {}
-  constexpr void on_edge_minimized(sourced_edge_desc_type&& edesc) {}
-  constexpr void on_edge_not_minimized(sourced_edge_desc_type&& edesc) {}
+  constexpr void on_examine_edge(const sourced_edge_desc_type& edesc) {}
+  constexpr void on_edge_relaxed(const sourced_edge_desc_type& edesc) {}
+  constexpr void on_edge_not_relaxed(const sourced_edge_desc_type& edesc) {}
+  constexpr void on_edge_minimized(const sourced_edge_desc_type& edesc) {}
+  constexpr void on_edge_not_minimized(const sourced_edge_desc_type& edesc) {}
 };
 
 template <class G, class Visitor>
@@ -86,10 +80,10 @@ concept bellman_visitor = //is_arithmetic<typename Visitor::distance_type> &&
  */
 template <index_adjacency_list G, forward_range Predecessors, class OutputIterator>
 requires output_iterator<OutputIterator, vertex_id_t<G>>
-void find_negative_cycle(G&                                   g,
-                         const Predecessors&                  predecessor,
-                         const std::optional<vertex_id_t<G>>& cycle_vertex_id,
-                         OutputIterator                       out_cycle) {
+void find_negative_cycle(G&                              g,
+                         const Predecessors&             predecessor,
+                         const optional<vertex_id_t<G>>& cycle_vertex_id,
+                         OutputIterator                  out_cycle) {
   // Does a negative weight cycle exist?
   if (cycle_vertex_id.has_value()) {
     vertex_id_t<G> uid = cycle_vertex_id.value();
@@ -137,7 +131,7 @@ template <index_adjacency_list G,
           input_range          Sources,
           random_access_range  Distances,
           random_access_range  Predecessors,
-          class WF      = std::function<range_value_t<Distances>(edge_reference_t<G>)>,
+          class WF      = function<range_value_t<Distances>(edge_reference_t<G>)>,
           class Visitor = bellman_visitor_base<G>,
           class Compare = less<range_value_t<Distances>>,
           class Combine = plus<range_value_t<Distances>>>
@@ -148,7 +142,7 @@ requires convertible_to<range_value_t<Sources>, vertex_id_t<G>> &&      //
          sized_range<Predecessors> &&                                   //
          basic_edge_weight_function<G, WF, range_value_t<Distances>, Compare, Combine>
 // && bellman_visitor<G, Visitor>
-[[nodiscard]] std::optional<vertex_id_t<G>> bellman_ford_shortest_paths(
+[[nodiscard]] optional<vertex_id_t<G>> bellman_ford_shortest_paths(
       G&             g,
       const Sources& sources,
       Distances&     distances,
@@ -160,7 +154,7 @@ requires convertible_to<range_value_t<Sources>, vertex_id_t<G>> &&      //
   using id_type       = vertex_id_t<G>;
   using DistanceValue = range_value_t<Distances>;
   using weight_type   = invoke_result_t<WF, edge_reference_t<G>>;
-  using return_type   = std::optional<vertex_id_t<G>>;
+  using return_type   = optional<vertex_id_t<G>>;
 
   // relxing the target is the function of reducing the distance from the source to the target
   auto relax_target = [&g, &predecessor, &distances, &compare, &combine] //
@@ -240,7 +234,7 @@ requires convertible_to<range_value_t<Sources>, vertex_id_t<G>> &&      //
 template <index_adjacency_list G,
           random_access_range  Distances,
           random_access_range  Predecessors,
-          class WF      = std::function<range_value_t<Distances>(edge_reference_t<G>)>,
+          class WF      = function<range_value_t<Distances>(edge_reference_t<G>)>,
           class Visitor = bellman_visitor_base<G>,
           class Compare = less<range_value_t<Distances>>,
           class Combine = plus<range_value_t<Distances>>>
@@ -250,7 +244,7 @@ requires is_arithmetic_v<range_value_t<Distances>> &&                   //
          sized_range<Predecessors> &&                                   //
          basic_edge_weight_function<G, WF, range_value_t<Distances>, Compare, Combine>
 // && bellman_visitor<G, Visitor>
-[[nodiscard]] std::optional<vertex_id_t<G>> bellman_ford_shortest_paths(
+[[nodiscard]] optional<vertex_id_t<G>> bellman_ford_shortest_paths(
       G&                   g,
       const vertex_id_t<G> source,
       Distances&           distances,
@@ -265,7 +259,7 @@ requires is_arithmetic_v<range_value_t<Distances>> &&                   //
 
 
 /**
- * @brief Shortest distnaces from a single source using Bellman-Ford's single-source shortest paths 
+ * @brief Shortest distances from a single source using Bellman-Ford's single-source shortest paths 
  *        algorithm with a visitor.
  * 
  * This is identical to bellman_ford_shortest_paths() except that it does not require a predecessors range.
@@ -297,7 +291,7 @@ requires is_arithmetic_v<range_value_t<Distances>> &&                   //
 template <index_adjacency_list G,
           input_range          Sources,
           random_access_range  Distances,
-          class WF      = std::function<range_value_t<Distances>(edge_reference_t<G>)>,
+          class WF      = function<range_value_t<Distances>(edge_reference_t<G>)>,
           class Visitor = bellman_visitor_base<G>,
           class Compare = less<range_value_t<Distances>>,
           class Combine = plus<range_value_t<Distances>>>
@@ -306,7 +300,7 @@ requires convertible_to<range_value_t<Sources>, vertex_id_t<G>> && //
          sized_range<Distances> &&                                 //
          basic_edge_weight_function<G, WF, range_value_t<Distances>, Compare, Combine>
 //&& bellman_visitor<G, Visitor>
-[[nodiscard]] std::optional<vertex_id_t<G>> bellman_ford_shortest_distances(
+[[nodiscard]] optional<vertex_id_t<G>> bellman_ford_shortest_distances(
       G&             g,
       const Sources& sources,
       Distances&     distances,
@@ -315,13 +309,12 @@ requires convertible_to<range_value_t<Sources>, vertex_id_t<G>> && //
       Compare&& compare = less<range_value_t<Distances>>(),
       Combine&& combine = plus<range_value_t<Distances>>()) {
   return bellman_ford_shortest_paths(g, sources, distances, _null_predecessors, forward<WF>(weight),
-                                     std::forward<Visitor>(visitor), std::forward<Compare>(compare),
-                                     std::forward<Combine>(combine));
+                                     forward<Visitor>(visitor), forward<Compare>(compare), forward<Combine>(combine));
 }
 
 template <index_adjacency_list G,
           random_access_range  Distances,
-          class WF      = std::function<range_value_t<Distances>(edge_reference_t<G>)>,
+          class WF      = function<range_value_t<Distances>(edge_reference_t<G>)>,
           class Visitor = bellman_visitor_base<G>,
           class Compare = less<range_value_t<Distances>>,
           class Combine = plus<range_value_t<Distances>>>
@@ -329,7 +322,7 @@ requires is_arithmetic_v<range_value_t<Distances>> && //
          sized_range<Distances> &&                    //
          basic_edge_weight_function<G, WF, range_value_t<Distances>, Compare, Combine>
 //&& bellman_visitor<G, Visitor>
-[[nodiscard]] std::optional<vertex_id_t<G>> bellman_ford_shortest_distances(
+[[nodiscard]] optional<vertex_id_t<G>> bellman_ford_shortest_distances(
       G&                   g,
       const vertex_id_t<G> source,
       Distances&           distances,
@@ -338,8 +331,8 @@ requires is_arithmetic_v<range_value_t<Distances>> && //
       Compare&& compare = less<range_value_t<Distances>>(),
       Combine&& combine = plus<range_value_t<Distances>>()) {
   return bellman_ford_shortest_paths(g, subrange(&source, (&source + 1)), distances, _null_predecessors,
-                                     forward<WF>(weight), std::forward<Visitor>(visitor),
-                                     std::forward<Compare>(compare), std::forward<Combine>(combine));
+                                     forward<WF>(weight), forward<Visitor>(visitor), forward<Compare>(compare),
+                                     forward<Combine>(combine));
 }
 
 } // namespace graph

--- a/include/graph/algorithm/dijkstra_clrs.hpp
+++ b/include/graph/algorithm/dijkstra_clrs.hpp
@@ -83,7 +83,7 @@ constexpr auto print_types(Ts...) {
 template <adjacency_list      G,
           random_access_range Distance,
           random_access_range Predecessor,
-          class WF = std::function<range_value_t<Distance>(edge_reference_t<G>)>>
+          class WF = function<range_value_t<Distance>(edge_reference_t<G>)>>
 requires random_access_range<vertex_range_t<G>> &&                     //
          integral<vertex_id_t<G>> &&                                   //
          is_arithmetic_v<range_value_t<Distance>> &&                   //

--- a/include/graph/algorithm/dijkstra_shortest_paths.hpp
+++ b/include/graph/algorithm/dijkstra_shortest_paths.hpp
@@ -37,15 +37,15 @@ public:
   // Visitor Functions
 public:
   // vertex visitor functions
-  constexpr void on_initialize_vertex(vertex_desc_type&& vdesc) {}
-  constexpr void on_discover_vertex(vertex_desc_type&& vdesc) {}
-  constexpr void on_examine_vertex(vertex_desc_type&& vdesc) {}
-  constexpr void on_finish_vertex(vertex_desc_type&& vdesc) {}
+  constexpr void on_initialize_vertex(const vertex_desc_type& vdesc) {}
+  constexpr void on_discover_vertex(const vertex_desc_type& vdesc) {}
+  constexpr void on_examine_vertex(const vertex_desc_type& vdesc) {}
+  constexpr void on_finish_vertex(const vertex_desc_type& vdesc) {}
 
   // edge visitor functions
-  constexpr void on_examine_edge(sourced_edge_desc_type&& edesc) {}
-  constexpr void on_edge_relaxed(sourced_edge_desc_type&& edesc) {}
-  constexpr void on_edge_not_relaxed(sourced_edge_desc_type&& edesc) {}
+  constexpr void on_examine_edge(const sourced_edge_desc_type& edesc) {}
+  constexpr void on_edge_relaxed(const sourced_edge_desc_type& edesc) {}
+  constexpr void on_edge_not_relaxed(const sourced_edge_desc_type& edesc) {}
 };
 
 template <class G, class Visitor>
@@ -97,7 +97,7 @@ template <index_adjacency_list G,
           input_range          Sources,
           random_access_range  Distances,
           random_access_range  Predecessors,
-          class WF      = std::function<range_value_t<Distances>(edge_reference_t<G>)>,
+          class WF      = function<range_value_t<Distances>(edge_reference_t<G>)>,
           class Visitor = dijkstra_visitor_base<G>,
           class Compare = less<range_value_t<Distances>>,
           class Combine = plus<range_value_t<Distances>>>
@@ -188,7 +188,7 @@ void dijkstra_shortest_paths(
       visitor.on_examine_edge({uid, vid, uv});
 
       // Negative weights are not allowed for Dijkstra's algorithm
-      if constexpr (std::is_signed_v<weight_type>) {
+      if constexpr (is_signed_v<weight_type>) {
         if (w < zero) {
           throw std::out_of_range(
                 fmt::format("dijkstra_shortest_paths: invalid negative edge weight of '{}' encountered", w));
@@ -230,7 +230,7 @@ void dijkstra_shortest_paths(
 template <index_adjacency_list G,
           random_access_range  Distances,
           random_access_range  Predecessors,
-          class WF      = std::function<range_value_t<Distances>(edge_reference_t<G>)>,
+          class WF      = function<range_value_t<Distances>(edge_reference_t<G>)>,
           class Visitor = dijkstra_visitor_base<G>,
           class Compare = less<range_value_t<Distances>>,
           class Combine = plus<range_value_t<Distances>>>
@@ -282,7 +282,7 @@ void dijkstra_shortest_paths(
 template <index_adjacency_list G,
           input_range          Sources,
           random_access_range  Distances,
-          class WF      = std::function<range_value_t<Distances>(edge_reference_t<G>)>,
+          class WF      = function<range_value_t<Distances>(edge_reference_t<G>)>,
           class Visitor = dijkstra_visitor_base<G>,
           class Compare = less<range_value_t<Distances>>,
           class Combine = plus<range_value_t<Distances>>>
@@ -299,14 +299,13 @@ void dijkstra_shortest_distances(
       Visitor&& visitor = dijkstra_visitor_base<G>(),
       Compare&& compare = less<range_value_t<Distances>>(),
       Combine&& combine = plus<range_value_t<Distances>>()) {
-  dijkstra_shortest_paths(g, sources, distances, _null_predecessors, forward<WF>(weight),
-                          std::forward<Visitor>(visitor), std::forward<Compare>(compare),
-                          std::forward<Combine>(combine));
+  dijkstra_shortest_paths(g, sources, distances, _null_predecessors, forward<WF>(weight), forward<Visitor>(visitor),
+                          forward<Compare>(compare), forward<Combine>(combine));
 }
 
 template <index_adjacency_list G,
           random_access_range  Distances,
-          class WF      = std::function<range_value_t<Distances>(edge_reference_t<G>)>,
+          class WF      = function<range_value_t<Distances>(edge_reference_t<G>)>,
           class Visitor = dijkstra_visitor_base<G>,
           class Compare = less<range_value_t<Distances>>,
           class Combine = plus<range_value_t<Distances>>>
@@ -323,8 +322,7 @@ void dijkstra_shortest_distances(
       Compare&& compare = less<range_value_t<Distances>>(),
       Combine&& combine = plus<range_value_t<Distances>>()) {
   dijkstra_shortest_paths(g, subrange(&source, (&source + 1)), distances, _null_predecessors, forward<WF>(weight),
-                          std::forward<Visitor>(visitor), std::forward<Compare>(compare),
-                          std::forward<Combine>(combine));
+                          forward<Visitor>(visitor), forward<Compare>(compare), forward<Combine>(combine));
 }
 
 } // namespace graph

--- a/include/graph/algorithm/experimental/co_dijkstra.hpp
+++ b/include/graph/algorithm/experimental/co_dijkstra.hpp
@@ -82,7 +82,7 @@ template <index_adjacency_list G,
           random_access_range  Predecessors,
           class Compare = less<range_value_t<Distances>>,
           class Combine = plus<range_value_t<Distances>>,
-          class WF      = std::function<range_value_t<Distances>(edge_reference_t<G>)>>
+          class WF      = function<range_value_t<Distances>(edge_reference_t<G>)>>
 requires convertible_to<range_value_t<Seeds>, vertex_id_t<G>> &&        //
          is_arithmetic_v<range_value_t<Distances>> &&                   //
          convertible_to<vertex_id_t<G>, range_value_t<Predecessors>> && //
@@ -168,7 +168,7 @@ Generator<bfs_value_t<dijkstra_events, G>> co_dijkstra(
       dijkstra_yield_edge(dijkstra_events::examine_edge, uid, vid, uv);
 
       // Negative weights are not allowed for Dijkstra's algorithm
-      if constexpr (std::is_signed_v<weight_type>) {
+      if constexpr (is_signed_v<weight_type>) {
         if (w < zero) {
           throw graph_error("co_dijkstra: negative edge weight");
         }
@@ -233,10 +233,10 @@ template <index_adjacency_list G,
           random_access_range  Predecessors,
           class Compare    = less<range_value_t<Distances>>,
           class Combine    = plus<range_value_t<Distances>>,
-          class WF         = std::function<range_value_t<Distances>(edge_reference_t<G>)>,
+          class WF         = function<range_value_t<Distances>(edge_reference_t<G>)>,
           _queueable Queue = std::priority_queue<vertex_id_t<G>,
                                                  std::vector<vertex_id_t<G>>,
-                                                 std::greater<vertex_id_t<G>>>>
+                                                 greater<vertex_id_t<G>>>>
 requires is_arithmetic_v<range_value_t<Distances>> &&                   //
          convertible_to<vertex_id_t<G>, range_value_t<Predecessors>> && //
          basic_edge_weight_function<G, WF, range_value_t<Distances>, Compare, Combine>

--- a/include/graph/algorithm/experimental/visitor_dijkstra.hpp
+++ b/include/graph/algorithm/experimental/visitor_dijkstra.hpp
@@ -141,7 +141,7 @@ template <index_adjacency_list G,
           input_range         Sources,
           random_access_range Distances,
           random_access_range Predecessors,
-          class WF      = std::function<range_value_t<Distances>(edge_reference_t<G>)>,
+          class WF      = function<range_value_t<Distances>(edge_reference_t<G>)>,
           class Compare = less<range_value_t<Distances>>,
           class Combine = plus<range_value_t<Distances>>
           //queueable Que = _dijkstra_queue<G, Distances> // not used
@@ -241,7 +241,7 @@ void dijkstra_with_visitor(
       visitor.on_examine_edge({uid, vid, uv});
 
       // Negative weights are not allowed for Dijkstra's algorithm
-      if constexpr (std::is_signed_v<weight_type>) {
+      if constexpr (is_signed_v<weight_type>) {
         if (w < zero) {
           throw graph_error("dijkstra_with_visitor: negative edge weight");
         }
@@ -303,7 +303,7 @@ template <index_adjacency_list G,
           class Visitor,
           random_access_range Distances,
           random_access_range Predecessors,
-          class WF      = std::function<range_value_t<Distances>(edge_reference_t<G>)>,
+          class WF      = function<range_value_t<Distances>(edge_reference_t<G>)>,
           class Compare = less<range_value_t<Distances>>,
           class Combine = plus<range_value_t<Distances>>,
           queueable Que = _dijkstra_queue<G, Distances>>

--- a/include/graph/container/compressed_graph.hpp
+++ b/include/graph/container/compressed_graph.hpp
@@ -47,7 +47,7 @@ namespace graph::container {
  * @return A @c pair<VId,size_t> with the max vertex id used and the number of edges scanned.
 */
 template <class VId, class EV, forward_range ERng, class EProj = identity>
-requires copyable_edge<invoke_result<EProj, range_value_t<ERng>>, VId, EV>
+requires copyable_edge<invoke_result_t<EProj, range_value_t<ERng>>, VId, EV>
 constexpr auto max_vertex_id(const ERng& erng, const EProj& eprojection) {
   size_t edge_count = 0;
   VId    max_id     = 0;
@@ -167,7 +167,7 @@ public: // Operations
   constexpr void swap(csr_row_values& other) noexcept { swap(v_, other.v_); }
 
   template <forward_range VRng, class VProj = identity>
-  //requires views::copyable_vertex<invoke_result<VProj, range_value_t<VRng>>, VId, VV>
+  //requires views::copyable_vertex<invoke_result_t<VProj, range_value_t<VRng>>, VId, VV>
   constexpr void load_row_values(const VRng& vrng, VProj projection, size_type vertex_count) {
     if constexpr (sized_range<VRng>)
       vertex_count = max(vertex_count, size(vrng));
@@ -185,7 +185,7 @@ public: // Operations
   }
 
   template <forward_range VRng, class VProj = identity>
-  //requires views::copyable_vertex<invoke_result<VProj, range_value_t<VRng>>, VId, VV>
+  //requires views::copyable_vertex<invoke_result_t<VProj, range_value_t<VRng>>, VId, VV>
   constexpr void load_row_values(VRng&& vrng, VProj projection, size_type vertex_count) {
     if constexpr (sized_range<VRng>)
       vertex_count = max(vertex_count, std::ranges::size(vrng));
@@ -446,7 +446,7 @@ public: // Construction/Destruction
    * @param alloc                Allocator to use for internal containers
   */
   template <forward_range ERng, forward_range PartRng, class EProj = identity>
-  //requires copyable_edge<invoke_result<EProj, range_value_t<ERng>>, VId, EV> && //
+  //requires copyable_edge<invoke_result_t<EProj, range_value_t<ERng>>, VId, EV> && //
   //               convertible_to<range_value_t<PartRng>, VId>
   constexpr compressed_graph_base(const ERng&    erng,
                                   EProj          eprojection         = {},
@@ -485,8 +485,8 @@ public: // Construction/Destruction
             class EProj = identity,
             class VProj = identity>
   requires convertible_to<range_value_t<PartRng>, VId>
-  //requires copyable_edge<invoke_result<EProj, range_value_t<ERng>>, VId, EV> &&
-  //      copyable_vertex<invoke_result<VProj, range_value_t<VRng>>, VId, VV>
+  //requires copyable_edge<invoke_result_t<EProj, range_value_t<ERng>>, VId, EV> &&
+  //      copyable_vertex<invoke_result_t<VProj, range_value_t<VRng>>, VId, VV>
   constexpr compressed_graph_base(const ERng&    erng,
                                   const VRng&    vrng,
                                   EProj          eprojection = {}, // eproj(eval) -> {source_id,target_id [,value]}
@@ -553,7 +553,7 @@ public:                            // Operations
    * @param  vprojection    Projection function for @c vrng values
   */
   template <forward_range VRng, class VProj = identity>
-  //requires views::copyable_vertex<invoke_result<VProj, range_value_t<VRng>>, VId, VV>
+  //requires views::copyable_vertex<invoke_result_t<VProj, range_value_t<VRng>>, VId, VV>
   constexpr void load_vertices(const VRng& vrng, VProj vprojection, size_type vertex_count = 0) {
     row_values_base::load_row_values(vrng, vprojection, max(vertex_count, size(vrng)));
   }
@@ -572,7 +572,7 @@ public:                            // Operations
    * @param vprojection Projection function for @c vrng values
   */
   template <forward_range VRng, class VProj = identity>
-  //requires views::copyable_vertex<invoke_result<VProj, range_value_t<VRng>>, VId, VV>
+  //requires views::copyable_vertex<invoke_result_t<VProj, range_value_t<VRng>>, VId, VV>
   constexpr void load_vertices(VRng& vrng, VProj vprojection = {}, size_type vertex_count = 0) {
     row_values_base::load_row_values(vrng, vprojection, max(vertex_count, size(vrng)));
   }
@@ -617,7 +617,7 @@ public:                            // Operations
    *                     edge range.
   */
   template <class ERng, class EProj = identity>
-  //requires views::copyable_edge<invoke_result<EProj, range_value_t<ERng>>, VId, EV>
+  //requires views::copyable_edge<invoke_result_t<EProj, range_value_t<ERng>>, VId, EV>
   constexpr void load_edges(ERng&& erng, EProj eprojection = {}, size_type vertex_count = 0, size_type edge_count = 0) {
     // should only be loading into an empty graph
     assert(row_index_.empty() && col_index_.empty() && static_cast<col_values_base&>(*this).empty());
@@ -631,8 +631,8 @@ public:                            // Operations
     // We can get the last vertex id from the list because erng is required to be ordered by
     // the source id. It's possible a target_id could have a larger id also, which is taken
     // care of at the end of this function.
-    vertex_count = max(vertex_count,
-                            static_cast<size_type>(last_erng_id(erng, eprojection) + 1)); // +1 for zero-based index
+    vertex_count =
+          max(vertex_count, static_cast<size_type>(last_erng_id(erng, eprojection) + 1)); // +1 for zero-based index
     reserve_vertices(vertex_count);
 
     // Eval number of input rows and reserve space for the edges, if possible
@@ -669,7 +669,7 @@ public:                            // Operations
 
   // The only diff with this and ERng&& is v_.push_back vs. v_.emplace_back
   template <class ERng, class EProj = identity>
-  //requires views::copyable_edge<invoke_result<EProj, range_value_t<ERng>>, VId, EV>
+  //requires views::copyable_edge<invoke_result_t<EProj, range_value_t<ERng>>, VId, EV>
   constexpr void
   load_edges(const ERng& erng, EProj eprojection = {}, size_type vertex_count = 0, size_type edge_count = 0) {
     // should only be loading into an empty graph
@@ -684,8 +684,8 @@ public:                            // Operations
     // We can get the last vertex id from the list because erng is required to be ordered by
     // the source id. It's possible a target_id could have a larger id also, which is taken
     // care of at the end of this function.
-    vertex_count = max(vertex_count,
-                            static_cast<size_type>(last_erng_id(erng, eprojection) + 1)); // +1 for zero-based index
+    vertex_count =
+          max(vertex_count, static_cast<size_type>(last_erng_id(erng, eprojection) + 1)); // +1 for zero-based index
     reserve_vertices(vertex_count);
 
     // Eval number of input rows and reserve space for the edges, if possible
@@ -752,8 +752,8 @@ public:                            // Operations
             class EProj = identity,
             class VProj = identity>
   requires convertible_to<range_value_t<PartRng>, VId>
-  //requires views::copyable_edge<invoke_result<EProj, range_value_t<ERng>>, VId, EV> &&
-  //      views::copyable_vertex<invoke_result<VProj, range_value_t<VRng>>, VId, VV>
+  //requires views::copyable_edge<invoke_result_t<EProj, range_value_t<ERng>>, VId, EV> &&
+  //      views::copyable_vertex<invoke_result_t<VProj, range_value_t<VRng>>, VId, VV>
   constexpr void load(const ERng& erng, const VRng& vrng, EProj eprojection = {}, VProj vprojection = {}) {
     load_edges(erng, eprojection);
     load_vertices(vrng, vprojection); // load the values
@@ -951,7 +951,7 @@ public: // Construction/Destruction
   // compressed_graph(gv&&, erng, eprojection, alloc)
 
   template <forward_range ERng, forward_range PartRng, class EProj = identity>
-  requires copyable_edge<invoke_result<EProj, range_value_t<ERng>>, VId, EV> &&
+  requires copyable_edge<invoke_result_t<EProj, range_value_t<ERng>>, VId, EV> &&
            convertible_to<range_value_t<PartRng>, VId>
   constexpr compressed_graph(const ERng&    erng,
                              EProj          eprojection,
@@ -960,7 +960,7 @@ public: // Construction/Destruction
         : base_type(erng, eprojection, partition_start_ids, alloc) {}
 
   template <forward_range ERng, forward_range PartRng, class EProj = identity>
-  requires copyable_edge<invoke_result<EProj, range_value_t<ERng>>, VId, EV> &&
+  requires copyable_edge<invoke_result_t<EProj, range_value_t<ERng>>, VId, EV> &&
                  convertible_to<range_value_t<PartRng>, VId>
   constexpr compressed_graph(const graph_value_type& value,
                              const ERng&             erng,
@@ -970,7 +970,7 @@ public: // Construction/Destruction
         : base_type(erng, eprojection, partition_start_ids, alloc), value_(value) {}
 
   template <forward_range ERng, forward_range PartRng, class EProj = identity>
-  requires copyable_edge<invoke_result<EProj, range_value_t<ERng>>, VId, EV> &&
+  requires copyable_edge<invoke_result_t<EProj, range_value_t<ERng>>, VId, EV> &&
                  convertible_to<range_value_t<PartRng>, VId>
   constexpr compressed_graph(graph_value_type&& value,
                              const ERng&        erng,
@@ -988,8 +988,8 @@ public: // Construction/Destruction
             forward_range PartRng,
             class EProj = identity,
             class VProj = identity>
-  requires copyable_edge<invoke_result<EProj, range_value_t<ERng>>, VId, EV> &&
-           copyable_vertex<invoke_result<VProj, range_value_t<VRng>>, VId, VV> &&
+  requires copyable_edge<invoke_result_t<EProj, range_value_t<ERng>>, VId, EV> &&
+           copyable_vertex<invoke_result_t<VProj, range_value_t<VRng>>, VId, VV> &&
            convertible_to<range_value_t<PartRng>, VId>
   constexpr compressed_graph(const ERng&    erng,
                              const VRng&    vrng,
@@ -1004,8 +1004,8 @@ public: // Construction/Destruction
             forward_range PartRng,
             class EProj = identity,
             class VProj = identity>
-  requires copyable_edge<invoke_result<EProj, range_value_t<ERng>>, VId, EV> &&
-                 copyable_vertex<invoke_result<VProj, range_value_t<VRng>>, VId, VV> &&
+  requires copyable_edge<invoke_result_t<EProj, range_value_t<ERng>>, VId, EV> &&
+                 copyable_vertex<invoke_result_t<VProj, range_value_t<VRng>>, VId, VV> &&
                  convertible_to<range_value_t<PartRng>, VId>
   constexpr compressed_graph(const graph_value_type& value,
                              const ERng&             erng,
@@ -1021,8 +1021,8 @@ public: // Construction/Destruction
             forward_range PartRng,
             class EProj = identity,
             class VProj = identity>
-  requires copyable_edge<invoke_result<EProj, range_value_t<ERng>>, VId, EV> &&
-                 copyable_vertex<invoke_result<VProj, range_value_t<VRng>>, VId, VV> &&
+  requires copyable_edge<invoke_result_t<EProj, range_value_t<ERng>>, VId, EV> &&
+                 copyable_vertex<invoke_result_t<VProj, range_value_t<VRng>>, VId, VV> &&
                  convertible_to<range_value_t<PartRng>, VId>
   constexpr compressed_graph(graph_value_type&& value,
                              const ERng&        erng,
@@ -1095,8 +1095,8 @@ public: // Construction/Destruction
             class EProj           = identity,
             class VProj           = identity,
             forward_range PartRng = std::vector<VId>>
-  requires copyable_edge<invoke_result<EProj, range_value_t<ERng>>, VId, EV> &&
-           copyable_vertex<invoke_result<VProj, range_value_t<VRng>>, VId, VV> &&
+  requires copyable_edge<invoke_result_t<EProj, range_value_t<ERng>>, VId, EV> &&
+           copyable_vertex<invoke_result_t<VProj, range_value_t<VRng>>, VId, VV> &&
            convertible_to<range_value_t<PartRng>, VId>
   constexpr compressed_graph(const ERng&    erng,
                              const VRng&    vrng,

--- a/include/graph/detail/graph_cpo.hpp
+++ b/include/graph/detail/graph_cpo.hpp
@@ -18,7 +18,8 @@ using std::_Choice_t;
 // Very similar (identical?) to std::_Fake_copy_init<T> in msvc.
 struct _Decay_copy final {
   template <typename _Tp>
-  constexpr std::decay_t<_Tp> operator()(_Tp&& __t) const noexcept(std::is_nothrow_convertible_v<_Tp, std::decay_t<_Tp>>) {
+  constexpr std::decay_t<_Tp> operator()(_Tp&& __t) const
+        noexcept(std::is_nothrow_convertible_v<_Tp, std::decay_t<_Tp>>) {
     return std::forward<_Tp>(__t);
   }
 } inline constexpr _Fake_copy_init{};
@@ -159,7 +160,7 @@ using graph_reference_t = std::add_lvalue_reference<G>;
  * @tparam G The graph type
  */
 template <class G>
-struct define_adjacency_matrix : public std::false_type {}; // specialized for graph container
+struct define_adjacency_matrix : public false_type {}; // specialized for graph container
 
 template <class G>
 struct is_adjacency_matrix : public define_adjacency_matrix<G> {};
@@ -205,7 +206,7 @@ namespace _Vertices {
 
     template <class _G>
     [[nodiscard]] static consteval _Choice_t<_St_ref> _Choose_ref() noexcept {
-      static_assert(std::is_lvalue_reference_v<_G>);
+      static_assert(is_lvalue_reference_v<_G>);
       if constexpr (_Has_ref_member<_G>) {
         return {_St_ref::_Member, noexcept(_Fake_copy_init(declval<_G>().vertices()))};
       } else if constexpr (_Has_ref_ADL<_G>) {
@@ -315,7 +316,7 @@ namespace _Vertex_id {
 
     template <class _G>
     [[nodiscard]] static consteval _Choice_t<_St_ref> _Choose_ref() noexcept {
-      static_assert(std::is_lvalue_reference_v<_G>);
+      static_assert(is_lvalue_reference_v<_G>);
       if constexpr (_Has_ref_member<_G>) {
         return {_St_ref::_Member,
                 noexcept(_Fake_copy_init(declval<vertex_iterator_t<_G>>()->vertex_id(declval<_G>())))};
@@ -490,7 +491,7 @@ namespace _Find_vertex {
 
     template <class _G>
     [[nodiscard]] static consteval _Choice_t<_St> _Choose() noexcept {
-      static_assert(std::is_lvalue_reference_v<_G>);
+      static_assert(is_lvalue_reference_v<_G>);
       if constexpr (_Has_member<_G>) {
         return {_St::_Member, noexcept(_Fake_copy_init(declval<_G>().find_vertex(declval<vertex_id_t<_G>>())))};
       } else if constexpr (_Has_ADL<_G>) {
@@ -591,7 +592,7 @@ namespace _Edges {
 
     template <class _G>
     [[nodiscard]] static consteval _Choice_t<_St_id> _Choose_id() noexcept {
-      static_assert(std::is_lvalue_reference_v<_G>);
+      static_assert(is_lvalue_reference_v<_G>);
       if constexpr (_Has_id_ADL<_G>) {
         return {_St_id::_Non_member,
                 noexcept(_Fake_copy_init(edges(declval<_G>(), declval<vertex_id_t<_G>>())))}; // intentional ADL
@@ -608,7 +609,7 @@ namespace _Edges {
 
     template <class _G>
     [[nodiscard]] static consteval _Choice_t<_St_ref> _Choose_ref() noexcept {
-      static_assert(std::is_lvalue_reference_v<_G>);
+      static_assert(is_lvalue_reference_v<_G>);
       if constexpr (_Has_ref_member<_G>) {
         return {_St_ref::_Member, noexcept(_Fake_copy_init(declval<vertex_reference_t<_G>>().edges(declval<_G>())))};
       } else if constexpr (_Has_ref_ADL<_G>) {
@@ -752,7 +753,7 @@ namespace _NumEdges {
 
     template <class _G>
     [[nodiscard]] static consteval _Choice_t<_St_ref> _Choose_ref() noexcept {
-      static_assert(std::is_lvalue_reference_v<_G>);
+      static_assert(is_lvalue_reference_v<_G>);
       if constexpr (_Has_ref_member<_G>) {
         return {_St_ref::_Member, noexcept(_Fake_copy_init(declval<_G>().num_edges()))};
       } else if constexpr (_Has_ref_ADL<_G>) {
@@ -861,7 +862,7 @@ namespace _Target_id {
 
     template <class _G>
     [[nodiscard]] static consteval _Choice_t<_St_adjl_ref> _Choose_adjl_ref() noexcept {
-      static_assert(std::is_lvalue_reference_v<_G>);
+      static_assert(is_lvalue_reference_v<_G>);
 
       if constexpr (_Has_adjl_ref_member<_G>) {
         return {_St_adjl_ref::_Member,
@@ -890,7 +891,7 @@ namespace _Target_id {
 
     template <class _E>
     [[nodiscard]] static consteval _Choice_t<_St_edgl_ref> _Choose_edgl_ref() noexcept {
-      //static_assert(std::is_lvalue_reference_v<_E>);
+      //static_assert(is_lvalue_reference_v<_E>);
 
       if constexpr (_Has_edgl_ref_member<_E>) {
         return {_St_edgl_ref::_Member, noexcept(_Fake_copy_init(declval<_E&>().target_id()))};
@@ -1050,7 +1051,7 @@ namespace _Source_id {
 
     template <class _G>
     [[nodiscard]] static consteval _Choice_t<_St_adjl_ref> _Choose_adjl_ref() noexcept {
-      static_assert(std::is_lvalue_reference_v<_G>);
+      static_assert(is_lvalue_reference_v<_G>);
       if constexpr (_Has_adjl_ref_member<_G>) {
         return {_St_adjl_ref::_Member,
                 noexcept(_Fake_copy_init(declval<edge_reference_t<_G>>().source_id(declval<_G>())))};
@@ -1070,7 +1071,7 @@ namespace _Source_id {
 
     template <class _E>
     [[nodiscard]] static consteval _Choice_t<_St_edgl_ref> _Choose_edgl_ref() noexcept {
-      //static_assert(std::is_lvalue_reference_v<_E>);
+      //static_assert(is_lvalue_reference_v<_E>);
       if constexpr (_Has_edgl_ref_member<_E>) {
         return {_St_edgl_ref::_Member, noexcept(_Fake_copy_init(declval<_E>().source_id()))};
       } else if constexpr (_Has_edgl_ref_ADL<_E>) {
@@ -1196,7 +1197,7 @@ namespace _Target {
 
     template <class _G>
     [[nodiscard]] static consteval _Choice_t<_St_ref> _Choose_ref() noexcept {
-      static_assert(std::is_lvalue_reference_v<_G>);
+      static_assert(is_lvalue_reference_v<_G>);
 
       if constexpr (_Has_ref_ADL<_G>) {
         return {_St_ref::_Non_member,
@@ -1279,7 +1280,7 @@ namespace _Source {
 
     template <class _G>
     [[nodiscard]] static consteval _Choice_t<_St_ref> _Choose_ref() noexcept {
-      static_assert(std::is_lvalue_reference_v<_G>);
+      static_assert(is_lvalue_reference_v<_G>);
       if constexpr (_Has_ref_ADL<_G>) {
         return {_St_ref::_Non_member,
                 noexcept(_Fake_copy_init(source(declval<_G>(), declval<edge_reference_t<_G>>())))}; // intentional ADL
@@ -1384,7 +1385,7 @@ namespace _Find_vertex_edge {
 
     template <class _G>
     [[nodiscard]] static consteval _Choice_t<_St_ref> _Choose_ref() noexcept {
-      static_assert(std::is_lvalue_reference_v<_G>);
+      static_assert(is_lvalue_reference_v<_G>);
       if constexpr (_Has_ref_member<_G>) {
         return {_St_ref::_Member, noexcept(_Fake_copy_init(declval<vertex_reference_t<_G>>().find_vertex_edge(
                                         declval<_G>(), declval<vertex_id_t<_G>>())))};
@@ -1407,7 +1408,7 @@ namespace _Find_vertex_edge {
 
     template <class _G>
     [[nodiscard]] static consteval _Choice_t<_St_id> _Choose_id() noexcept {
-      static_assert(std::is_lvalue_reference_v<_G>);
+      static_assert(is_lvalue_reference_v<_G>);
       if constexpr (_Has_id_ADL<_G>) {
         return {_St_id::_Non_member,
                 noexcept(_Fake_copy_init(find_vertex_edge(declval<_G>(), declval<vertex_id_t<_G>>(),
@@ -1526,7 +1527,7 @@ namespace _Contains_edge {
 
     template <class _G>
     [[nodiscard]] static consteval _Choice_t<_St_ref> _Choose_ref() noexcept {
-      static_assert(std::is_lvalue_reference_v<_G>);
+      static_assert(is_lvalue_reference_v<_G>);
       if constexpr (_Has_ref_ADL<_G>) {
         return {_St_ref::_Non_member,
                 noexcept(_Fake_copy_init(contains_edge(declval<_G>(), declval<vertex_id_t<_G>>(),
@@ -1631,7 +1632,7 @@ namespace _Partition_id {
 
     template <class _G>
     [[nodiscard]] static consteval _Choice_t<_St_id> _Choose_id() noexcept {
-      static_assert(std::is_lvalue_reference_v<_G>);
+      static_assert(is_lvalue_reference_v<_G>);
       if constexpr (_Has_id_ADL<_G>) {
         return {_St_id::_Non_member,
                 noexcept(_Fake_copy_init(partition_id(declval<_G>(), declval<vertex_id_t<_G>>())))}; // intentional ADL
@@ -1647,7 +1648,7 @@ namespace _Partition_id {
 
     template <class _G>
     [[nodiscard]] static consteval _Choice_t<_St_ref> _Choose_ref() noexcept {
-      static_assert(std::is_lvalue_reference_v<_G>);
+      static_assert(is_lvalue_reference_v<_G>);
       if constexpr (_Has_ref_member<_G>) {
         return {_St_ref::_Member,
                 noexcept(_Fake_copy_init(declval<vertex_reference_t<_G>>().partition_id(declval<_G>())))};
@@ -1777,7 +1778,7 @@ namespace _NumVertices {
 
     template <class _G>
     [[nodiscard]] static consteval _Choice_t<_St_ref> _Choose_ref() noexcept {
-      static_assert(std::is_lvalue_reference_v<_G>);
+      static_assert(is_lvalue_reference_v<_G>);
       if constexpr (_Has_ref_member<_G>) {
         return {_St_ref::_Member, noexcept(_Fake_copy_init(declval<_G>().num_vertices()))};
       } else if constexpr (_Has_ref_ADL<_G>) {
@@ -1794,7 +1795,7 @@ namespace _NumVertices {
 
     template <class _G>
     [[nodiscard]] static consteval _Choice_t<_St_id> _Choose_id() noexcept {
-      static_assert(std::is_lvalue_reference_v<_G>);
+      static_assert(is_lvalue_reference_v<_G>);
       if constexpr (_Has_id_ADL<_G>) {
         return {
               _St_id::_Non_member,
@@ -1919,7 +1920,7 @@ namespace _Degree {
 
     template <class _G>
     [[nodiscard]] static consteval _Choice_t<_St_id> _Choose_id() noexcept {
-      static_assert(std::is_lvalue_reference_v<_G>);
+      static_assert(is_lvalue_reference_v<_G>);
       if constexpr (_Has_id_ADL<_G>) {
         return {_St_id::_Non_member,
                 noexcept(_Fake_copy_init(degree(declval<_G>(), declval<vertex_id_t<_G>>())))}; // intentional ADL
@@ -1936,7 +1937,7 @@ namespace _Degree {
 
     template <class _G>
     [[nodiscard]] static consteval _Choice_t<_St_ref> _Choose_ref() noexcept {
-      static_assert(std::is_lvalue_reference_v<_G>);
+      static_assert(is_lvalue_reference_v<_G>);
       if constexpr (_Has_ref_member<_G>) {
         return {_St_ref::_Member, noexcept(_Fake_copy_init(declval<vertex_reference_t<_G>>().degree(declval<_G>())))};
       } else if constexpr (_Has_ref_ADL<_G>) {
@@ -1975,7 +1976,7 @@ namespace _Degree {
       if constexpr (_Strat_ref == _St_ref::_Member) {
         return u.degree(__g);
       } else if constexpr (_Strat_ref == _St_ref::_Non_member) {
-        return degree(__g, u);              // intentional ADL
+        return degree(__g, u);      // intentional ADL
       } else if constexpr (_Strat_ref == _St_ref::_Auto_eval) {
         return size(edges(__g, u)); // default impl
       } else {
@@ -2003,7 +2004,7 @@ namespace _Degree {
       constexpr _St_id _Strat_id = _Choice_id<_G&>._Strategy;
 
       if constexpr (_Strat_id == _St_id::_Non_member) {
-        return degree(__g, uid);              // intentional ADL
+        return degree(__g, uid);      // intentional ADL
       } else if constexpr (_Strat_id == _St_id::_Auto_eval) {
         return size(edges(__g, uid)); // default impl
       } else {
@@ -2047,7 +2048,7 @@ namespace _Vertex_value {
 
     template <class _G>
     [[nodiscard]] static consteval _Choice_t<_St_ref> _Choose_ref() noexcept {
-      static_assert(std::is_lvalue_reference_v<_G>);
+      static_assert(is_lvalue_reference_v<_G>);
       if constexpr (_Has_ref_member<_G>) {
         return {_St_ref::_Member, noexcept(_Fake_copy_init(declval<vertex_reference_t<_G>>().vertex_value(
                                         declval<graph_reference_t<_G>>())))};
@@ -2150,7 +2151,7 @@ namespace _Edge_value {
 
     template <class _G>
     [[nodiscard]] static consteval _Choice_t<_St_adjl_ref> _Choose_adjl_ref() noexcept {
-      static_assert(std::is_lvalue_reference_v<_G>);
+      static_assert(is_lvalue_reference_v<_G>);
       if constexpr (_Has_adjl_ref_member<_G>) {
         return {
               _St_adjl_ref::_Member,
@@ -2174,7 +2175,7 @@ namespace _Edge_value {
 
     template <class _E>
     [[nodiscard]] static consteval _Choice_t<_St_edgl_ref> _Choose_edgl_ref() noexcept {
-      //static_assert(std::is_lvalue_reference_v<_E>);
+      //static_assert(is_lvalue_reference_v<_E>);
       if constexpr (_Has_edgl_ref_member<_E>) {
         return {_St_edgl_ref::_Member, noexcept(_Fake_copy_init(declval<_E>().edge_value()))};
       } else if constexpr (_Has_edgl_ref_ADL<_E>) {
@@ -2307,7 +2308,7 @@ namespace _Graph_value {
 
     template <class _G>
     [[nodiscard]] static consteval _Choice_t<_St_ref> _Choose_ref() noexcept {
-      static_assert(std::is_lvalue_reference_v<_G>);
+      static_assert(is_lvalue_reference_v<_G>);
       if constexpr (_Has_ref_member<_G>) {
         return {_St_ref::_Member, noexcept(_Fake_copy_init(declval<graph_reference_t<_G>>().graph_value()))};
       } else if constexpr (_Has_ref_ADL<_G>) {
@@ -2384,7 +2385,7 @@ namespace _Num_partitions {
 
     template <class _G>
     [[nodiscard]] static consteval _Choice_t<_St_ref> _Choose_ref() noexcept {
-      static_assert(std::is_lvalue_reference_v<_G>);
+      static_assert(is_lvalue_reference_v<_G>);
       if constexpr (_Has_ref_member<_G>) {
         return {_St_ref::_Member, noexcept(_Fake_copy_init(declval<_G>().num_partitions()))};
       } else if constexpr (_Has_ref_ADL<_G>) {
@@ -2483,7 +2484,7 @@ namespace _HasEdge {
 
     template <class _G>
     [[nodiscard]] static consteval _Choice_t<_St_ref> _Choose_ref() noexcept {
-      static_assert(std::is_lvalue_reference_v<_G>);
+      static_assert(is_lvalue_reference_v<_G>);
       if constexpr (_Has_ref_member<_G>) {
         return {_St_ref::_Member, noexcept(_Fake_copy_init(declval<_G>().has_edge()))};
       } else if constexpr (_Has_ref_ADL<_G>) {
@@ -2501,7 +2502,7 @@ namespace _HasEdge {
 
     //template <class _G>
     //[[nodiscard]] static consteval _Choice_t<_St_id> _Choose_id() noexcept {
-    //  static_assert(std::is_lvalue_reference_v<_G>);
+    //  static_assert(is_lvalue_reference_v<_G>);
     //  if constexpr (_Has_id_ADL<_G>) {
     //    return {
     //          _St_id::_Non_member,

--- a/include/graph/detail/graph_using.hpp
+++ b/include/graph/detail/graph_using.hpp
@@ -3,6 +3,8 @@
 #include <concepts>
 #include <ranges>
 #include <tuple>
+#include <functional>
+#include <optional>
 
 namespace graph {
 // Containers are not included to avoid potential conflicts: vector, list, string, etc.
@@ -14,14 +16,28 @@ using std::tuple_element_t;
 using std::tuple_size_v;
 using std::reference_wrapper;
 using std::forward_iterator_tag;
+using std::declval;
+
+// functional types
 using std::plus;
 using std::less;
-using std::declval;
+using std::greater;
+using std::identity;
+using std::function;
+using std::invoke;
+
+// optional types
+using std::optional;
 
 // type traits
 using std::is_arithmetic_v;
 using std::is_convertible_v;
 using std::is_same_v;
+using std::is_invocable_v;
+using std::is_arithmetic_v;
+using std::is_void_v;
+using std::is_lvalue_reference_v;
+using std::is_signed_v;
 
 using std::remove_cv_t;
 using std::remove_const_t;
@@ -29,15 +45,15 @@ using std::remove_volatile_t;
 using std::remove_reference_t;
 using std::remove_pointer_t;
 using std::remove_cvref_t;
-using std::is_arithmetic_v;
-using std::is_void_v;
+using std::invoke_result_t;
+
+using std::false_type;
+using std::true_type;
 
 // concepts
 using std::same_as;
 using std::convertible_to;
 using std::integral;
-using std::invoke_result;
-using std::invoke_result_t;
 using std::invocable;
 using std::regular_invocable;
 
@@ -61,7 +77,6 @@ using std::random_access_iterator;
 using std::contiguous_iterator;
 
 // range types
-using std::identity;
 using std::ranges::subrange;
 
 using std::ranges::iterator_t;

--- a/include/graph/edgelist.hpp
+++ b/include/graph/edgelist.hpp
@@ -107,7 +107,7 @@ namespace edgelist {
                            };
 
   template <class EL>
-  struct is_directed : public std::false_type {}; // specialized for graph container
+  struct is_directed : public false_type {}; // specialized for graph container
 
   template <class EL>
   inline constexpr bool is_directed_v = is_directed<EL>::value;

--- a/include/graph/graph.hpp
+++ b/include/graph/graph.hpp
@@ -374,7 +374,7 @@ concept has_contains_edge = requires(G&& g, vertex_id_t<G> uid, vertex_id_t<G> v
  */
 
 template <class G>
-struct define_unordered_edge : public std::false_type {}; // specialized for graph container edge
+struct define_unordered_edge : public false_type {}; // specialized for graph container edge
 
 template <class G>                                   // For exposition only
 concept unordered_edge = basic_sourced_edge<G> && define_unordered_edge<G>::value;

--- a/include/graph/views/breadth_first_search.hpp
+++ b/include/graph/views/breadth_first_search.hpp
@@ -209,7 +209,7 @@ public:
   using bfs_range_type   = vertices_breadth_first_search_view<graph_type, VVF, Alloc>;
 
   using vertex_value_func = remove_reference_t<VVF>;
-  using vertex_value_type = std::invoke_result_t<VVF, vertex_reference>;
+  using vertex_value_type = invoke_result_t<VVF, vertex_reference>;
 
 public:
   vertices_breadth_first_search_view(graph_type&    g,
@@ -455,7 +455,7 @@ public:
   using bfs_range_type      = edges_breadth_first_search_view<G, EVF, Sourced, Alloc>;
 
   using edge_value_func = remove_reference_t<EVF>;
-  using edge_value_type = std::invoke_result_t<EVF, edge_reference_type>;
+  using edge_value_type = invoke_result_t<EVF, edge_reference_type>;
 
 public:
   edges_breadth_first_search_view(G& g, vertex_id_type seed, const EVF& value_fn, const Alloc& alloc = Alloc())
@@ -717,7 +717,7 @@ namespace views {
 
       template <class _G, class _Alloc>
       [[nodiscard]] static consteval _Choice_t<_St_ref> _Choose_ref() noexcept {
-        //static_assert(std::is_lvalue_reference_v<_G>);
+        //static_assert(is_lvalue_reference_v<_G>);
         if constexpr (_Has_ref_ADL<_G, _Alloc>) {
           return {_St_ref::_Non_member,
                   noexcept(_Fake_copy_init(vertices_breadth_first_search(declval<_G>(), declval<vertex_id_t<_G>>(),
@@ -735,7 +735,7 @@ namespace views {
 
       template <class _G, class _VVF, class _Alloc>
       [[nodiscard]] static consteval _Choice_t<_St_ref_vvf> _Choose_ref_vvf() noexcept {
-        //static_assert(std::is_lvalue_reference_v<_G>);
+        //static_assert(is_lvalue_reference_v<_G>);
         if constexpr (_Has_ref_vvf_ADL<_G, _VVF, _Alloc>) {
           return {_St_ref_vvf::_Non_member, noexcept(_Fake_copy_init(vertices_breadth_first_search(
                                                   declval<_G>(), declval<vertex_id_t<_G>>(), declval<_VVF>(),
@@ -866,7 +866,7 @@ namespace views {
 
       template <class _G, class _Alloc>
       [[nodiscard]] static consteval _Choice_t<_St_ref> _Choose_ref() noexcept {
-        //static_assert(std::is_lvalue_reference_v<_G>);
+        //static_assert(is_lvalue_reference_v<_G>);
         if constexpr (_Has_ref_ADL<_G, _Alloc>) {
           return {_St_ref::_Non_member,
                   noexcept(_Fake_copy_init(edges_breadth_first_search(declval<_G>(), declval<vertex_id_t<_G>>(),
@@ -884,7 +884,7 @@ namespace views {
 
       template <class _G, class _EVF, class _Alloc>
       [[nodiscard]] static consteval _Choice_t<_St_ref_evf> _Choose_ref_evf() noexcept {
-        //static_assert(std::is_lvalue_reference_v<_G>);
+        //static_assert(is_lvalue_reference_v<_G>);
         if constexpr (_Has_ref_evf_ADL<_G, _EVF, _Alloc>) {
           return {_St_ref_evf::_Non_member, noexcept(_Fake_copy_init(edges_breadth_first_search(
                                                   declval<_G>(), declval<vertex_id_t<_G>>(), declval<_EVF>(),
@@ -1019,7 +1019,7 @@ namespace views {
 
       template <class _G, class _Alloc>
       [[nodiscard]] static consteval _Choice_t<_St_ref> _Choose_ref() noexcept {
-        //static_assert(std::is_lvalue_reference_v<_G>);
+        //static_assert(is_lvalue_reference_v<_G>);
         if constexpr (_Has_ref_ADL<_G, _Alloc>) {
           return {_St_ref::_Non_member,
                   noexcept(_Fake_copy_init(sourced_edges_breadth_first_search(declval<_G>(), declval<vertex_id_t<_G>>(),
@@ -1037,7 +1037,7 @@ namespace views {
 
       template <class _G, class _EVF, class _Alloc>
       [[nodiscard]] static consteval _Choice_t<_St_ref_evf> _Choose_ref_evf() noexcept {
-        //static_assert(std::is_lvalue_reference_v<_G>);
+        //static_assert(is_lvalue_reference_v<_G>);
         if constexpr (_Has_ref_evf_ADL<_G, _EVF, _Alloc>) {
           return {_St_ref_evf::_Non_member, noexcept(_Fake_copy_init(sourced_edges_breadth_first_search(
                                                   declval<_G>(), declval<vertex_id_t<_G>>(), declval<_EVF>(),

--- a/include/graph/views/depth_first_search.hpp
+++ b/include/graph/views/depth_first_search.hpp
@@ -685,7 +685,7 @@ namespace views {
 
       template <class _G, class _Alloc>
       [[nodiscard]] static consteval _Choice_t<_St_ref> _Choose_ref() noexcept {
-        //static_assert(std::is_lvalue_reference_v<_G>);
+        //static_assert(is_lvalue_reference_v<_G>);
         if constexpr (_Has_ref_ADL<_G, _Alloc>) {
           return {_St_ref::_Non_member,
                   noexcept(_Fake_copy_init(vertices_depth_first_search(declval<_G>(), declval<vertex_id_t<_G>>(),
@@ -703,7 +703,7 @@ namespace views {
 
       template <class _G, class _VVF, class _Alloc>
       [[nodiscard]] static consteval _Choice_t<_St_ref_vvf> _Choose_ref_vvf() noexcept {
-        //static_assert(std::is_lvalue_reference_v<_G>);
+        //static_assert(is_lvalue_reference_v<_G>);
         if constexpr (_Has_ref_vvf_ADL<_G, _VVF, _Alloc>) {
           return {_St_ref_vvf::_Non_member, noexcept(_Fake_copy_init(vertices_depth_first_search(
                                                   declval<_G>(), declval<vertex_id_t<_G>>(), declval<_VVF>(),
@@ -834,7 +834,7 @@ namespace views {
 
       template <class _G, class _Alloc>
       [[nodiscard]] static consteval _Choice_t<_St_ref> _Choose_ref() noexcept {
-        //static_assert(std::is_lvalue_reference_v<_G>);
+        //static_assert(is_lvalue_reference_v<_G>);
         if constexpr (_Has_ref_ADL<_G, _Alloc>) {
           return {_St_ref::_Non_member,
                   noexcept(_Fake_copy_init(edges_depth_first_search(declval<_G>(), declval<vertex_id_t<_G>>(),
@@ -852,7 +852,7 @@ namespace views {
 
       template <class _G, class _EVF, class _Alloc>
       [[nodiscard]] static consteval _Choice_t<_St_ref_evf> _Choose_ref_evf() noexcept {
-        //static_assert(std::is_lvalue_reference_v<_G>);
+        //static_assert(is_lvalue_reference_v<_G>);
         if constexpr (_Has_ref_evf_ADL<_G, _EVF, _Alloc>) {
           return {_St_ref_evf::_Non_member, noexcept(_Fake_copy_init(edges_depth_first_search(
                                                   declval<_G>(), declval<vertex_id_t<_G>>(), declval<_EVF>(),
@@ -987,7 +987,7 @@ namespace views {
 
       template <class _G, class _Alloc>
       [[nodiscard]] static consteval _Choice_t<_St_ref> _Choose_ref() noexcept {
-        //static_assert(std::is_lvalue_reference_v<_G>);
+        //static_assert(is_lvalue_reference_v<_G>);
         if constexpr (_Has_ref_ADL<_G, _Alloc>) {
           return {_St_ref::_Non_member,
                   noexcept(_Fake_copy_init(sourced_edges_depth_first_search(declval<_G>(), declval<vertex_id_t<_G>>(),
@@ -1005,7 +1005,7 @@ namespace views {
 
       template <class _G, class _EVF, class _Alloc>
       [[nodiscard]] static consteval _Choice_t<_St_ref_evf> _Choose_ref_evf() noexcept {
-        //static_assert(std::is_lvalue_reference_v<_G>);
+        //static_assert(is_lvalue_reference_v<_G>);
         if constexpr (_Has_ref_evf_ADL<_G, _EVF, _Alloc>) {
           return {_St_ref_evf::_Non_member, noexcept(_Fake_copy_init(sourced_edges_depth_first_search(
                                                   declval<_G>(), declval<vertex_id_t<_G>>(), declval<_EVF>(),

--- a/include/graph/views/edgelist.hpp
+++ b/include/graph/views/edgelist.hpp
@@ -174,7 +174,7 @@ public:
       value_.shadow_.edge  = &*uvi_;
       value_.shadow_.value = invoke(*value_fn_, *uvi_);
     } else {
-      value_.shadow_ = {vertex_id(*g_, ui_), target_id(*g_, *uvi_), &*uvi_, std::invoke(*value_fn_, *uvi_)};
+      value_.shadow_ = {vertex_id(*g_, ui_), target_id(*g_, *uvi_), &*uvi_, invoke(*value_fn_, *uvi_)};
     }
     return value_.value_;
   }
@@ -444,7 +444,7 @@ namespace views {
       // edgelist(g)
       template <class _G>
       [[nodiscard]] static consteval _Choice_t<_St_adjlist_all> _Choose_all() noexcept {
-        static_assert(std::is_lvalue_reference_v<_G>);
+        static_assert(is_lvalue_reference_v<_G>);
         if constexpr (_Has_adjlist_all_ADL<_G>) {
           return {_St_adjlist_all::_Non_member, noexcept(_Fake_copy_init(edgelist(declval<_G>())))}; // intentional ADL
         } else if constexpr (_Can_adjlist_all_eval<_G>) {
@@ -460,7 +460,7 @@ namespace views {
       // edgelist(g,evf)
       template <class _G, class EVF>
       [[nodiscard]] static consteval _Choice_t<_St_adjlist_all> _Choose_all_evf() noexcept {
-        static_assert(std::is_lvalue_reference_v<_G>);
+        static_assert(is_lvalue_reference_v<_G>);
         if constexpr (_Has_adjlist_all_evf_ADL<_G, EVF>) {
           return {_St_adjlist_all::_Non_member,
                   noexcept(_Fake_copy_init(edgelist(declval<_G>(), declval<EVF>())))}; // intentional ADL
@@ -478,7 +478,7 @@ namespace views {
       // edgelist(g,uid,vid)
       template <class _G>
       [[nodiscard]] static consteval _Choice_t<_St_adjlist_idrng> _Choose_idrng() noexcept {
-        static_assert(std::is_lvalue_reference_v<_G>);
+        static_assert(is_lvalue_reference_v<_G>);
         if constexpr (_Has_adjlist_idrng_ADL<_G>) {
           return {_St_adjlist_idrng::_Non_member,
                   noexcept(_Fake_copy_init(edgelist(declval<_G>(), declval<vertex_id_t<_G>>(),
@@ -496,7 +496,7 @@ namespace views {
       // edgelist(g,uid,vid,evf)
       template <class _G, class EVF>
       [[nodiscard]] static consteval _Choice_t<_St_adjlist_idrng> _Choose_idrng_evf() noexcept {
-        static_assert(std::is_lvalue_reference_v<_G>);
+        static_assert(is_lvalue_reference_v<_G>);
         if constexpr (_Has_adjlist_idrng_evf_ADL<_G, EVF>) {
           return {_St_adjlist_idrng::_Non_member,
                   noexcept(_Fake_copy_init(edgelist(declval<_G>(), declval<vertex_id_t<_G>>(),
@@ -515,7 +515,7 @@ namespace views {
       // edgelist(elr,proj)
       template <class ELR, class Proj>
       [[nodiscard]] static consteval _Choice_t<_St_edgelist_all> _Choose_elr_proj() noexcept {
-        static_assert(std::is_lvalue_reference_v<ELR>);
+        static_assert(is_lvalue_reference_v<ELR>);
         if constexpr (_Has_edgelist_all_proj_ADL<ELR, Proj>) {
           return {_St_edgelist_all::_Non_member,
                   noexcept(_Fake_copy_init(edgelist(declval<ELR>(), declval<Proj>())))}; // intentional ADL

--- a/include/graph/views/incidence.hpp
+++ b/include/graph/views/incidence.hpp
@@ -44,7 +44,7 @@ public:
   using edge_iterator       = vertex_edge_iterator_t<graph_type>;
   using edge_type           = edge_t<graph_type>;
   using edge_reference_type = edge_reference_t<graph_type>;
-  using edge_value_type     = std::invoke_result_t<EVF, edge_reference_type>;
+  using edge_value_type     = invoke_result_t<EVF, edge_reference_type>;
 
   using iterator_category = forward_iterator_tag;
   using value_type        = edge_descriptor<const vertex_id_type, Sourced, edge_reference_type, edge_value_type>;
@@ -108,7 +108,7 @@ public:
       value_.shadow_.target_id = target_id(*g_, *iter_);
     }
     value_.shadow_.edge  = &*iter_;
-    value_.shadow_.value = std::invoke(*value_fn_, *iter_);
+    value_.shadow_.value = invoke(*value_fn_, *iter_);
     return value_.value_;
   }
 
@@ -275,7 +275,7 @@ namespace views {
 
       template <class _G>
       [[nodiscard]] static consteval _Choice_t<_St_id> _Choose_id() noexcept {
-        static_assert(std::is_lvalue_reference_v<_G>);
+        static_assert(is_lvalue_reference_v<_G>);
         if constexpr (_Has_id_ADL<_G>) {
           return {_St_id::_Non_member,
                   noexcept(_Fake_copy_init(incidence(declval<_G>(), declval<vertex_id_t<_G>>())))}; // intentional ADL
@@ -294,7 +294,7 @@ namespace views {
 
       template <class _G, class EVF>
       [[nodiscard]] static consteval _Choice_t<_St_id> _Choose_id_evf() noexcept {
-        static_assert(std::is_lvalue_reference_v<_G>);
+        static_assert(is_lvalue_reference_v<_G>);
         if constexpr (_Has_id_evf_ADL<_G, EVF>) {
           return {_St_id::_Non_member, noexcept(_Fake_copy_init(incidence(declval<_G>(), declval<vertex_id_t<_G>>(),
                                                                           declval<EVF>())))}; // intentional ADL

--- a/include/graph/views/neighbors.hpp
+++ b/include/graph/views/neighbors.hpp
@@ -120,7 +120,7 @@ public:
       value_.shadow_.target    = const_cast<shadow_vertex_type*>(&target(*g_, *iter_));
     }
     value_.shadow_.value =
-          std::invoke(*value_fn_, *value_.shadow_.target); // 'value' undeclared identifier (.value not in struct?)
+          invoke(*value_fn_, *value_.shadow_.target); // 'value' undeclared identifier (.value not in struct?)
     return value_.value_;
   }
 
@@ -297,7 +297,7 @@ namespace views {
 
       template <class _G>
       [[nodiscard]] static consteval _Choice_t<_St_id> _Choose_id() noexcept {
-        static_assert(std::is_lvalue_reference_v<_G>);
+        static_assert(is_lvalue_reference_v<_G>);
         if constexpr (_Has_id_ADL<_G>) {
           return {_St_id::_Non_member,
                   noexcept(_Fake_copy_init(neighbors(declval<_G>(), declval<vertex_id_t<_G>>())))}; // intentional ADL
@@ -316,7 +316,7 @@ namespace views {
 
       template <class _G, class VVF>
       [[nodiscard]] static consteval _Choice_t<_St_id> _Choose_id_vvf() noexcept {
-        static_assert(std::is_lvalue_reference_v<_G>);
+        static_assert(is_lvalue_reference_v<_G>);
         if constexpr (_Has_id_vvf_ADL<_G, VVF>) {
           return {_St_id::_Non_member, noexcept(_Fake_copy_init(neighbors(declval<_G>(), declval<vertex_id_t<_G>>(),
                                                                           declval<VVF>())))}; // intentional ADL

--- a/include/graph/views/vertexlist.hpp
+++ b/include/graph/views/vertexlist.hpp
@@ -38,7 +38,7 @@ public:
   using vertex_type           = vertex_t<graph_type>;
   using vertex_reference_type = range_reference_t<vertex_range_type>;
   using vertex_value_func     = VVF;
-  using vertex_value_type     = std::invoke_result_t<VVF, vertex_type&>;
+  using vertex_value_type     = invoke_result_t<VVF, vertex_type&>;
 
   using iterator_category = forward_iterator_tag;
   using value_type        = vertex_descriptor<const vertex_id_t<graph_type>, vertex_reference_type, vertex_value_type>;
@@ -82,7 +82,7 @@ public:
   constexpr reference operator*() const {
     value_.shadow_.vertex = &*iter_;
     if constexpr (!is_void_v<vertex_value_type>)
-      value_.shadow_.value = std::invoke(*this->value_fn_, *iter_);
+      value_.shadow_.value = invoke(*this->value_fn_, *iter_);
     return value_.value_;
   }
 
@@ -249,7 +249,7 @@ namespace views {
       // all
       template <class _G>
       [[nodiscard]] static consteval _Choice_t<_St_all> _Choose_all() noexcept {
-        static_assert(std::is_lvalue_reference_v<_G>);
+        static_assert(is_lvalue_reference_v<_G>);
 
         if constexpr (_Has_all_ADL<_G>) {
           return {_St_all::_Non_member, noexcept(_Fake_copy_init(vertexlist(declval<_G>())))}; // intentional ADL
@@ -266,7 +266,7 @@ namespace views {
 
       template <class _G, class VVF>
       [[nodiscard]] static consteval _Choice_t<_St_all> _Choose_vvf_all() noexcept {
-        static_assert(std::is_lvalue_reference_v<_G>);
+        static_assert(is_lvalue_reference_v<_G>);
 
         if constexpr (_Has_all_vvf_ADL<_G, VVF>) {
           return {_St_all::_Non_member,
@@ -287,7 +287,7 @@ namespace views {
       // rng
       template <class _G, class Rng>
       [[nodiscard]] static consteval _Choice_t<_St_rng> _Choose_rng() noexcept {
-        static_assert(std::is_lvalue_reference_v<_G>);
+        static_assert(is_lvalue_reference_v<_G>);
 
         if constexpr (_Has_rng_ADL<_G, Rng>) {
           return {_St_rng::_Non_member,
@@ -308,7 +308,7 @@ namespace views {
 
       template <class _G, class Rng, class VVF>
       [[nodiscard]] static consteval _Choice_t<_St_rng> _Choose_vvf_rng() noexcept {
-        static_assert(std::is_lvalue_reference_v<_G>);
+        static_assert(is_lvalue_reference_v<_G>);
 
         if constexpr (_Has_rng_vvf_ADL<_G, Rng, VVF>) {
           return {_St_rng::_Non_member, noexcept(_Fake_copy_init(vertexlist(declval<_G>(), declval<Rng>(),


### PR DESCRIPTION
The main motivation is to allow copy/paste into the paper without requiring
editing of any std:: concepts or types

Additionall entries added for convenience.

Fixed error where std::invoke_result was used instead of std::invoke_result_t
in compressed_graph