### PR TITLE
Fix bug in compressed_graph

### DIFF
--- a/include/graph/container/compressed_graph.hpp
+++ b/include/graph/container/compressed_graph.hpp
@@ -171,8 +171,8 @@ public: // Operations
   //requires views::copyable_vertex<invoke_result_t<VProj, range_value_t<VRng>>, VId, VV>
   constexpr void load_row_values(const VRng& vrng, VProj projection, size_type vertex_count) {
     if constexpr (sized_range<VRng>)
-      vertex_count = max(vertex_count, size(vrng));
-    resize(size(vrng));
+      vertex_count = max(vertex_count, std::ranges::size(vrng));
+    resize(std::ranges::size(vrng));
 
     for (auto&& vtx : vrng) {
       const auto& [id, value] = projection(vtx);
@@ -745,14 +745,11 @@ public: // Operations
    * @param vrng            Input vertex range
    * @param eprojection     Edge projection function object
    * @param vprojection     Vertex projection function object
-   * @param partition_start_ids  Range of starting vertex ids for each partition. If empty, all vertices are in partition 0.
   */
   template <forward_range ERng,
             forward_range VRng,
-            forward_range PartRng,
             class EProj = identity,
             class VProj = identity>
-  requires convertible_to<range_value_t<PartRng>, VId>
   //requires views::copyable_edge<invoke_result_t<EProj, range_value_t<ERng>>, VId, EV> &&
   //      views::copyable_vertex<invoke_result_t<VProj, range_value_t<VRng>>, VId, VV>
   constexpr void load(const ERng& erng, const VRng& vrng, EProj eprojection = {}, VProj vprojection = {}) {

--- a/include/graph/container/container_utility.hpp
+++ b/include/graph/container/container_utility.hpp
@@ -82,8 +82,8 @@ constexpr auto push_or_insert(C& container) {
 template <class C, class K>
 requires has_array_operator<C, K>
 constexpr auto assign_or_insert(C& container) {
-  if constexpr (random_access_range<C>) {
-    static_assert(sized_range<C>, "random_access container is assumed to have size()");
+  if constexpr (::std::ranges::random_access_range<C>) {
+    static_assert(::std::ranges::sized_range<C>, "random_access container is assumed to have size()");
     return [&container](const K& id, typename C::value_type&& value) {
       typename C::size_type k = static_cast<typename C::size_type>(id);
       assert(k < container.size());
@@ -99,8 +99,8 @@ constexpr auto assign_or_insert(C& container) {
 // ERng is a forward_range because it is traversed twice; once to get the max vertex_id
 // and a second time to load the edges.
 template <class ERng, class EIdFnc, class EValueFnc>
-concept edge_value_extractor = forward_range<ERng> && invocable<EIdFnc, typename ERng::value_type> &&
-                               invocable<EValueFnc, typename ERng::value_type>;
+concept edge_value_extractor = std::ranges::forward_range<ERng> && ::std::invocable<EIdFnc, typename ERng::value_type> &&
+                               ::std::invocable<EValueFnc, typename ERng::value_type>;
 
 namespace detail {
   //--------------------------------------------------------------------------------------

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,6 +62,7 @@ set(UNITTEST_SOURCES
 
     "descriptor_tests.cpp"
     "tests.cpp"
+    "compressed_graph_tests.cpp"
 )
 
 foreach(SOURCE IN LISTS UNITTEST_SOURCES)

--- a/tests/compressed_graph_tests.cpp
+++ b/tests/compressed_graph_tests.cpp
@@ -1,0 +1,32 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+#include "graph/container/compressed_graph.hpp"
+#include <string>
+#include <vector>
+
+//            A         
+//      0.8 /  \ 0.4     
+//         B    C       
+//      0.1 \  / 0.2    
+//           D          
+
+const std::vector<graph::copyable_edge_t<unsigned, double>> ve {
+  {0, 1, 0.8}, {0, 2, 0.4}, {1, 3, 0.1}, {2, 3, 0.2}
+};
+
+const std::vector<graph::copyable_vertex_t<unsigned, std::string>> vv {
+  {0, "A"}, {1, "B"}, {2, "C"}, {3, "D"}
+};
+
+TEST_CASE("compressed_graph constructor", "[compressed_graph]") {
+  using graph_t = graph::container::compressed_graph<double, std::string>;
+  const graph_t g(ve, vv);
+    
+  std::vector<std::string> vertex_names;
+    
+  for (graph_t::vertex_type const& u : vertices(g))
+    vertex_names.push_back(vertex_value(g, u));
+        
+  REQUIRE(vertex_names == std::vector<std::string>{"A", "B", "C", "D"});
+}
+


### PR DESCRIPTION
Fix the constructor in compressed_graph that takses a list of edfges and a list of vertices.